### PR TITLE
Upgrade Ollama to 0.12.10 and Tika to 3.2.3.0-full

### DIFF
--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -137,7 +137,7 @@ nano <FILENAME>
 
 The following files have settings to review 
 
-* `docker-compose.yml` - Review "#CUSTOMIZE" comments to modify for your hardware.
+* `docker-compose.yml` - Review "#CUSTOMIZE" comments to modify for your hardware. As of November 2025 this file pins `ollama/ollama:0.12.10` and `apache/tika:3.2.3.0-full`; you can update these tags in the future as newer stable images are released.
 * `ephemeral_app.py` - Review "#CUSTOMIZE" comments to modify branding and time zone.
 * `theme.css` - Review "#CUSTOMIZE" comments to modify colors and (optional) add text logo.
 * `system_prompt_template.md` - Instructions sent to LLM each conversation - Modify for your goals/environment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Large‑language‑model back‑end (Ollama)
   # --------------------------------------------------------------------------
   ollama:
-    image: ollama/ollama:0.10.1
+    image: ollama/ollama:0.12.10
     container_name: ollama
     restart: unless-stopped
     networks: [llm-net]
@@ -52,7 +52,7 @@ services:
   # Apache Tika – document parsing
   # --------------------------------------------------------------------------
   tika-server:
-    image: apache/tika:3.2.1.0-full
+    image: apache/tika:3.2.3.0-full
     container_name: tika-server
     restart: unless-stopped
     networks: [llm-net]


### PR DESCRIPTION
- Update docker-compose.yml to use:
  - `ollama/ollama:0.12.10` (LLM backend)
  - `apache/tika:3.2.3.0-full` (document parsing)
- Document these pinned versions in the System Deployment Guide.

