### PR TITLE
Fix parsing resilience and multimodal safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This tool offers a straightforward set of capabilities to facilitate interaction
 - **Document and Image Uploads:** Submit one or more files (including PDFs, documents, and spreadsheets, handling over 100 formats via Apache Tika), allowing the model to incorporate user content into its responses.
 - **Multimodal Functionality:** Leverage Gemma 3's ability to process images in conjunction with text, enabling analysis of visual elements like diagrams or photographs.
 - **Customizable Interface:** Incorporate a personal logo or adjust the appearance if desired using Streamlit, maintaining a clean and user-friendly design.
-- **Ephemeral Sessions:** Chat content is cleared when you refresh, start a new conversation, or close your browser. No conversation history is stored in a database. Document parsing is cached only for the duration of your session to improve performance on repeated uploads.
+- **Ephemeral Sessions:** Chat content is cleared when you start a new conversation or close your browser. No conversation history is stored in a database. Document parsing is cached only for the duration of your session to improve performance on repeated uploads.
 - **Simplified Deployment:** The solution utilizes Docker Compose for containerized setup, making it accessible even for those new to such environments.
 
 ## Privacy Notes


### PR DESCRIPTION
### Motivation
- Tika health checks could falsely report the parser as offline when the root endpoint returned non-200 responses, disabling document parsing.
- Image uploads were always embedded into the LLM payload which breaks chats when a text-only model is selected.
- Document parsing had no request timeout and extracted text was injected unbounded into prompts, risking hangs and context-length overflows.
- Upload-only interactions could pass empty/null text to the UI and backend, and UI/README promised that refresh clears chats which was not actually implemented.

### Description
- Improve Tika resilience by probing multiple endpoints and adding a `TIKA_TIMEOUT_S` request timeout passed to `parser.from_buffer` for safer parsing calls.
- Add truncation helpers and config via `MAX_DOC_CHARS` and `MAX_CONTEXT_CHARS` to limit per-document and total injected context and show warnings when truncation occurs (`truncate_text`).
- Convert image handling to data URLs (avoid storing raw bytes long-term) and add `model_supports_images()` (checks `LLM_SUPPORTS_VISION`, model-name heuristics, and Ollama `/api/show`) to skip sending images to models that do not support vision while warning the user.
- Handle file-only uploads by defaulting an informative `user_text` (`"Please analyze the uploaded files."`) and update the welcome banner and `README.md` to correctly reflect that sessions are cleared only when starting a new conversation or closing the browser.

### Testing
- Started the app locally with `streamlit run ephemeral_app.py`, which launched successfully.
- Captured the welcome screen using a Playwright script, which completed and produced a screenshot artifact.
- No unit tests were present or executed as part of this change, and no CI runs were triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696081fa2ddc8328829232025a920808)