### PR TITLE
Harden Windows service installer preflights and docs

### DIFF
--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -29,9 +29,10 @@ Complete all items in this phase before moving on.
    - Install the newest production driver for your GPU model.
    - Reboot if prompted.
 
-3. **Install Python 3.11+**
+3. **Install Python 3.11+ (all users)**
    - Download from [python.org downloads](https://www.python.org/downloads/windows/).
-   - During install, make sure you check **"Add Python to PATH"**.
+   - During install, check **"Add Python to PATH"** and choose **"Install for all users"**.
+   - In Windows Settings, disable the Microsoft Store **App execution aliases** for `python.exe` and `python3.exe` if they are enabled.
 
 4. **Install Java 21+ (Temurin recommended)**
    - Download from [Adoptium Temurin Releases](https://adoptium.net/temurin/releases/).
@@ -146,13 +147,14 @@ git clone https://github.com/eowensai/EphemerAl.git C:\EphemerAl
 
 ```powershell
 Set-Location C:\EphemerAl
-pip install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 ```
 
 3. **Verify the app runs**
 
 ```powershell
-streamlit run ephemeral_app.py
+python -m streamlit run ephemeral_app.py
 ```
 
 - Open `http://localhost:8501`.

--- a/services/Install-EphemerAlServices.ps1
+++ b/services/Install-EphemerAlServices.ps1
@@ -62,13 +62,70 @@ if (-not $nssmCommand) {
 Write-Ok "NSSM found: $($nssmCommand.Source)"
 
 Write-Step "Locating Python executable for Streamlit service..."
+$pythonExe = $null
 $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-if (-not $pythonCommand) {
-    Write-Fail "Python is not on PATH. Install Python and ensure 'python' is available in PATH."
+if ($pythonCommand) {
+    $pythonExe = $pythonCommand.Source
+}
+
+if ($pythonExe -and $pythonExe -like '*\\WindowsApps\\python.exe') {
+    # Windows App Execution Alias often resolves to a shim and cannot run as a service account.
+    $pythonExe = $null
+}
+
+if (-not $pythonExe) {
+    $pyLauncher = Get-Command py -ErrorAction SilentlyContinue
+    if ($pyLauncher) {
+        try {
+            $resolvedPython = (& py -3 -c "import sys; print(sys.executable)").Trim()
+            if ($resolvedPython) {
+                $pythonExe = $resolvedPython
+            }
+        } catch {
+            # Keep null and fail with a user-friendly message below.
+        }
+    }
+}
+
+if (-not $pythonExe) {
+    Write-Fail "Could not resolve a real Python executable for the service."
+    Write-Host "Install Python for all users and disable the Windows App Execution Alias for python.exe if enabled."
     exit 1
 }
-$pythonExe = $pythonCommand.Source
+
+if (-not (Test-Path $pythonExe)) {
+    Write-Fail "Resolved Python executable does not exist: $pythonExe"
+    exit 1
+}
 Write-Ok "Python found: $pythonExe"
+
+Write-Step "Validating required application files..."
+
+$requiredPaths = @(
+    @{ Label = 'Ollama executable'; Path = 'C:\Ollama\ollama.exe' },
+    @{ Label = 'Tika server JAR'; Path = 'C:\Tika\tika-server-standard.jar' },
+    @{ Label = 'EphemerAl app file'; Path = 'C:\EphemerAl\ephemeral_app.py' }
+)
+
+foreach ($item in $requiredPaths) {
+    if (-not (Test-Path -Path $item.Path)) {
+        Write-Fail "$($item.Label) not found at $($item.Path)"
+        Write-Host "Verify installation paths or update this script before rerunning."
+        exit 1
+    }
+    Write-Ok "$($item.Label) found: $($item.Path)"
+}
+
+
+Write-Step "Validating Streamlit module availability..."
+try {
+    & $pythonExe -c "import streamlit" | Out-Null
+    Write-Ok "Streamlit module is available for the resolved Python interpreter."
+} catch {
+    Write-Fail "Streamlit is not installed for: $pythonExe"
+    Write-Host "From C:\EphemerAl run: python -m pip install -r requirements.txt"
+    exit 1
+}
 
 $ollamaEnv = @(
     'OLLAMA_HOST=0.0.0.0'

--- a/services/README.md
+++ b/services/README.md
@@ -22,6 +22,8 @@ For full, step-by-step deployment instructions, use the root [`System Deployment
 
 The install script currently assumes these defaults:
 
+The installer also validates that it can resolve a real Python interpreter (not the Windows Store App Execution Alias shim), checks required files exist, and confirms `streamlit` is importable before creating services.
+
 - Ollama executable: `C:\Ollama\ollama.exe`
 - Ollama model directory: `C:\Ollama\models`
 - Tika JAR location: `C:\Tika\tika-server-standard.jar`


### PR DESCRIPTION
### Motivation
- Prevent common breakpoints when deploying EphemerAl on a fresh Windows 11 Pro machine, especially failures caused by the Windows Store `python.exe` alias shim. 
- Fail fast and provide actionable guidance when required runtime files or Python dependencies are missing so NSSM services are not created in a broken state. 
- Align the deployment guide with a Windows-first install path (all-users Python, disable app execution aliases, use `python -m` invocations).

### Description
- Update `services/Install-EphemerAlServices.ps1` to resolve a real Python executable and reject the Windows Store App Execution Alias (`...\WindowsApps\python.exe`), falling back to `py -3` when appropriate. 
- Add preflight checks in `services/Install-EphemerAlServices.ps1` to verify required files exist at `C:\Ollama\ollama.exe`, `C:\Tika\tika-server-standard.jar`, and `C:\EphemerAl\ephemeral_app.py` before registering services. 
- Add a Streamlit import check in the installer that fails with a clear remediation (`python -m pip install -r requirements.txt`) if `streamlit` is not available for the resolved interpreter. 
- Update `System Deployment Guide.md` to recommend installing Python for all users, disabling the Microsoft Store App Execution Aliases for `python.exe`/`python3.exe`, and to use `python -m pip` and `python -m streamlit`; and update `services/README.md` to note the new installer validation behavior.

### Testing
- Ran `python -m py_compile ephemeral_app.py` which completed successfully. 
- Verified the updated installer script logic by static inspection and unit-friendly checks in this environment, but could not execute PowerShell validation commands here because `powershell`/`pwsh` are not available in the CI environment. 
- Committed changes and ensured no Python syntax regressions after edits (re-ran `python -m py_compile ephemeral_app.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdfe2ba448328974aef4e6f2db50a)