### PR TITLE
Resolve Java for Tika, enable NSSM service logs, and tighten Windows deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Recommended baseline:
 
 - **Operating System:** Windows 11 Pro or Enterprise, fully updated.
 - **Graphics Processing Unit:** NVIDIA GPU (or equivalent capable hardware) sized for your chosen model.
-- **Runtime dependencies:** Python 3.x, Java 21+, Ollama, and NSSM installed on Windows.
+- **Runtime dependencies:** Python 3.11+, Java 21+, Ollama, and NSSM installed on Windows.
 
 ## Getting Started
 

--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -29,9 +29,10 @@ Complete all items in this phase before moving on.
    - Install the newest production driver for your GPU model.
    - Reboot if prompted.
 
-3. **Install Python 3.11+**
+3. **Install Python 3.11+ (all users)**
    - Download from [python.org downloads](https://www.python.org/downloads/windows/).
-   - During install, make sure you check **"Add Python to PATH"**.
+   - During install, check **"Add Python to PATH"** and choose **"Install for all users"**.
+   - In Windows Settings, disable the Microsoft Store **App execution aliases** for `python.exe` and `python3.exe` if they are enabled.
 
 4. **Install Java 21+ (Temurin recommended)**
    - Download from [Adoptium Temurin Releases](https://adoptium.net/temurin/releases/).
@@ -146,13 +147,17 @@ git clone https://github.com/eowensai/EphemerAl.git C:\EphemerAl
 
 ```powershell
 Set-Location C:\EphemerAl
-pip install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 ```
 
 3. **Verify the app runs**
 
+Before launching Streamlit manually, set this environment variable in the same PowerShell window so the Python Tika client uses your existing Tika service only:
+
 ```powershell
-streamlit run ephemeral_app.py
+$env:TIKA_CLIENT_ONLY = "true"
+python -m streamlit run ephemeral_app.py
 ```
 
 - Open `http://localhost:8501`.
@@ -172,23 +177,25 @@ These start automatically at boot and run even when no user is signed in.
 
 1. **Open PowerShell as Administrator**
 
-2. **Run the install script**
+2. **Allow scripts in this session (temporary)**
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
+```
+
+> This only applies to the current PowerShell window and resets when you close it.
+
+3. **Run the install script**
 
 ```powershell
 C:\EphemerAl\services\Install-EphemerAlServices.ps1
 ```
 
-3. **Verify service health**
+4. **Verify service health**
 
 ```powershell
 C:\EphemerAl\services\Check-EphemerAlServices.ps1
 ```
-
-> **Tip:** If script execution is blocked by policy, run this in the same elevated PowerShell session:
->
-> ```powershell
-> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
-> ```
 
 ---
 
@@ -261,6 +268,14 @@ C:\Ollama\ollama.exe create gemma3-prod -f Modelfile
 
 5. **Restart Ollama service**
 
+First verify the service exists and is running:
+
+```powershell
+Get-Service OllamaService
+```
+
+Then restart it:
+
 ```powershell
 nssm restart OllamaService
 ```
@@ -332,6 +347,14 @@ C:\Ollama\ollama.exe create gemma3-prod -f Modelfile
 
 5. **Restart Ollama service**
 
+First verify the service exists and is running:
+
+```powershell
+Get-Service OllamaService
+```
+
+Then restart it:
+
 ```powershell
 nssm restart OllamaService
 ```
@@ -351,6 +374,8 @@ New-NetFirewallRule -DisplayName "EphemerAl Port 8501" -Direction Inbound -Proto
 2. **Access the app over the network**
 
 Since services run natively on Windows, the application is directly accessible using the machine's IP address. No additional forwarding configuration is required.
+
+> **Security note:** The service script binds Ollama (`11434`) and Tika (`9998`) to `0.0.0.0` for local service compatibility. Keep Windows Firewall enabled and do not open those ports unless you intentionally need remote API access.
 
 Find the machine IP:
 

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -15,6 +15,10 @@ import streamlit as st
 import streamlit.components.v1 as components
 import requests
 import pytz
+
+# Keep the Tika Python client in remote-client mode by default to avoid local JAR startup/download surprises.
+os.environ.setdefault("TIKA_CLIENT_ONLY", "true")
+
 from tika import parser
 from openai import OpenAI
 
@@ -66,7 +70,7 @@ st.markdown(
 
 def load_css(path: str = "theme.css") -> None:
     """Load optional CSS overrides to customize Streamlit's default look."""
-    css_path = pathlib.Path(path)
+    css_path = pathlib.Path(__file__).parent / path
     if css_path.exists():
         st.markdown(f"<style>{css_path.read_text()}</style>", unsafe_allow_html=True)
 

--- a/services/Install-EphemerAlServices.ps1
+++ b/services/Install-EphemerAlServices.ps1
@@ -62,13 +62,88 @@ if (-not $nssmCommand) {
 Write-Ok "NSSM found: $($nssmCommand.Source)"
 
 Write-Step "Locating Python executable for Streamlit service..."
+$pythonExe = $null
 $pythonCommand = Get-Command python -ErrorAction SilentlyContinue
-if (-not $pythonCommand) {
-    Write-Fail "Python is not on PATH. Install Python and ensure 'python' is available in PATH."
+if ($pythonCommand) {
+    $pythonExe = $pythonCommand.Source
+}
+
+if ($pythonExe -and $pythonExe -like '*\\WindowsApps\\python.exe') {
+    # Windows App Execution Alias often resolves to a shim and cannot run as a service account.
+    $pythonExe = $null
+}
+
+if (-not $pythonExe) {
+    $pyLauncher = Get-Command py -ErrorAction SilentlyContinue
+    if ($pyLauncher) {
+        try {
+            $resolvedPython = (& py -3 -c "import sys; print(sys.executable)").Trim()
+            if ($resolvedPython) {
+                $pythonExe = $resolvedPython
+            }
+        } catch {
+            # Keep null and fail with a user-friendly message below.
+        }
+    }
+}
+
+if (-not $pythonExe) {
+    Write-Fail "Could not resolve a real Python executable for the service."
+    Write-Host "Install Python for all users and disable the Windows App Execution Alias for python.exe if enabled."
     exit 1
 }
-$pythonExe = $pythonCommand.Source
+
+if (-not (Test-Path $pythonExe)) {
+    Write-Fail "Resolved Python executable does not exist: $pythonExe"
+    exit 1
+}
 Write-Ok "Python found: $pythonExe"
+
+Write-Step "Locating Java executable for Tika service..."
+$javaCommand = Get-Command java -ErrorAction SilentlyContinue
+if (-not $javaCommand) {
+    Write-Fail "Java is not on PATH. Install Java 21+ and ensure System PATH includes the Java bin folder."
+    exit 1
+}
+$javaExe = $javaCommand.Source
+if (-not (Test-Path -Path $javaExe)) {
+    Write-Fail "Resolved Java executable does not exist: $javaExe"
+    exit 1
+}
+Write-Ok "Java found: $javaExe"
+
+Write-Step "Validating required application files..."
+
+$requiredPaths = @(
+    @{ Label = 'Ollama executable'; Path = 'C:\Ollama\ollama.exe' },
+    @{ Label = 'Tika server JAR'; Path = 'C:\Tika\tika-server-standard.jar' },
+    @{ Label = 'EphemerAl app file'; Path = 'C:\EphemerAl\ephemeral_app.py' }
+)
+
+foreach ($item in $requiredPaths) {
+    if (-not (Test-Path -Path $item.Path)) {
+        Write-Fail "$($item.Label) not found at $($item.Path)"
+        Write-Host "Verify installation paths or update this script before rerunning."
+        exit 1
+    }
+    Write-Ok "$($item.Label) found: $($item.Path)"
+}
+
+$logDirectory = 'C:\EphemerAl\logs'
+if (-not (Test-Path -Path $logDirectory)) {
+    New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+}
+Write-Ok "Service log directory ready: $logDirectory"
+
+Write-Step "Validating Streamlit module availability..."
+try {
+    & $pythonExe -c "import streamlit" | Out-Null
+    Write-Ok "Streamlit module is available for the resolved Python interpreter."
+} catch {
+    Write-Fail "Streamlit is not installed for: $pythonExe"
+    Write-Host "From C:\EphemerAl run: python -m pip install -r requirements.txt"
+    exit 1
+}
 
 $ollamaEnv = @(
     'OLLAMA_HOST=0.0.0.0'
@@ -98,7 +173,7 @@ $services = @(
     },
     @{
         Name = 'TikaService'
-        AppPath = 'java'
+        AppPath = $javaExe
         AppArgs = '-jar C:\Tika\tika-server-standard.jar --host 0.0.0.0 --port 9998'
         AppDirectory = 'C:\Tika'
         AppEnvironmentExtra = $tikaEnv
@@ -117,6 +192,15 @@ foreach ($svc in $services) {
     try {
         Write-Step "Installing $($svc.Name)..."
         Install-ServiceWithNssm -Name $svc.Name -AppPath $svc.AppPath -AppArgs $svc.AppArgs -AppDirectory $svc.AppDirectory -AppEnvironmentExtra $svc.AppEnvironmentExtra
+
+        $stdoutPath = Join-Path $logDirectory "$($svc.Name).out.log"
+        $stderrPath = Join-Path $logDirectory "$($svc.Name).err.log"
+        & nssm set $svc.Name AppStdout $stdoutPath | Out-Null
+        & nssm set $svc.Name AppStderr $stderrPath | Out-Null
+        & nssm set $svc.Name AppRotateFiles 1 | Out-Null
+        & nssm set $svc.Name AppRotateOnline 1 | Out-Null
+        & nssm set $svc.Name AppRotateBytes 10485760 | Out-Null
+
         $installResults[$svc.Name] = $true
         Write-Ok "$($svc.Name) installed and set to Automatic startup."
     } catch {

--- a/services/README.md
+++ b/services/README.md
@@ -22,6 +22,8 @@ For full, step-by-step deployment instructions, use the root [`System Deployment
 
 The install script currently assumes these defaults:
 
+The installer also validates that it can resolve a real Python interpreter (not the Windows Store App Execution Alias shim), resolves Java for Tika, checks required files exist, and confirms `streamlit` is importable before creating services.
+
 - Ollama executable: `C:\Ollama\ollama.exe`
 - Ollama model directory: `C:\Ollama\models`
 - Tika JAR location: `C:\Tika\tika-server-standard.jar`
@@ -56,28 +58,17 @@ Update the Tika JAR name/path in `TikaService` `AppArgs`, for example:
 
 If you install a different Tika release filename, point `-jar` to that exact file.
 
-## Configure NSSM log output locations
+## NSSM log output defaults
 
-The install script does not currently set NSSM file logging. You can enable it per service with commands like:
+The install script now configures logging automatically for all services in `C:\EphemerAl\logs`:
 
-```powershell
-nssm set OllamaService AppStdout C:\Logs\OllamaService.out.log
-nssm set OllamaService AppStderr C:\Logs\OllamaService.err.log
-nssm set TikaService AppStdout C:\Logs\TikaService.out.log
-nssm set TikaService AppStderr C:\Logs\TikaService.err.log
-nssm set EphemerAlApp AppStdout C:\Logs\EphemerAlApp.out.log
-nssm set EphemerAlApp AppStderr C:\Logs\EphemerAlApp.err.log
-```
+- `C:\EphemerAl\logs\OllamaService.out.log` / `.err.log`
+- `C:\EphemerAl\logs\TikaService.out.log` / `.err.log`
+- `C:\EphemerAl\logs\EphemerAlApp.out.log` / `.err.log`
 
-Optional rotation controls:
+It also enables basic rotation controls (`AppRotateFiles=1`, `AppRotateOnline=1`, `AppRotateBytes=10485760`).
 
-```powershell
-nssm set EphemerAlApp AppRotateFiles 1
-nssm set EphemerAlApp AppRotateOnline 1
-nssm set EphemerAlApp AppRotateBytes 10485760
-```
-
-Repeat for other services if desired.
+If you want custom locations, update them after install with `nssm set <ServiceName> AppStdout <Path>` and `AppStderr <Path>`.
 
 ## Add EPHEMERAL_TIMEZONE or EPHEMERAL_DEBUG to Streamlit service
 
@@ -116,7 +107,7 @@ You can also update the `$appEnv` block in `Install-EphemerAlServices.ps1` and r
 | `LLM_MODEL_NAME` | Model name sent in chat requests. | `gemma3-prod` |
 | `TIKA_URL` | Apache Tika server endpoint for document parsing. | `http://localhost:9998` |
 | `TIKA_TIMEOUT_S` | Timeout (seconds) for Tika parsing requests. | `15` |
-| `TIKA_CLIENT_ONLY` | When true, the Tika Python client skips local JAR startup and uses remote server mode only. | _No app default_ (service script sets `true`) |
+| `TIKA_CLIENT_ONLY` | When true, the Tika Python client skips local JAR startup and uses remote server mode only. | `true` (app default; service script also sets `true`) |
 | `DEFAULT_UPLOAD_PROMPT` | Prompt inserted when files are uploaded without text input. | `Please analyze the uploaded files.` |
 | `LLM_SUPPORTS_VISION` | Optional override for image capability detection (`true`/`false`). | Not set (auto-detect) |
 | `EPHEMERAL_TIMEZONE` | Optional IANA timezone name for app timestamps. | Not set (uses system local timezone) |


### PR DESCRIPTION
### Motivation
- Prevent service startup failures on fresh Windows installs by avoiding bare `java` invocation and other common plumbing issues that break NSSM-managed services. 
- Improve first-time troubleshooting by enabling service stdout/stderr logs and sensible defaults so operators can diagnose failures quickly. 
- Reduce surprising behavior during manual testing by making the app and docs align with service-mode assumptions (Tika client-only mode, exec policy guidance, CWD-independent assets).

### Description
- Update `services/Install-EphemerAlServices.ps1` to resolve Java at install time using `Get-Command java` and use the resolved full path as the `TikaService` `AppPath` instead of a bare `java` string. 
- Create `C:\EphemerAl\logs` during install and configure NSSM logging and rotation for each service with `AppStdout`, `AppStderr`, `AppRotateFiles`, `AppRotateOnline`, and `AppRotateBytes`. 
- Preserve and harden Python resolution logic for the Streamlit service and keep the existing preflight checks that verify required files (`C:\Ollama\ollama.exe`, `C:\Tika\tika-server-standard.jar`, `C:\EphemerAl\ephemeral_app.py`) and `streamlit` availability for the resolved interpreter. 
- Make app and docs changes: set `TIKA_CLIENT_ONLY=true` by default in `ephemeral_app.py` before importing `tika`, load `theme.css` relative to `__file__` instead of CWD, update `README.md` to state `Python 3.11+`, and update `System Deployment Guide.md` to (a) set a temporary `Set-ExecutionPolicy -Scope Process` before running the installer, (b) recommend `TIKA_CLIENT_ONLY=true` in-session when manually launching Streamlit, (c) verify service existence with `Get-Service` before restarting after model operations, and (d) add a security note about services binding to `0.0.0.0`. 
- Update `services/README.md` to document Java resolution, automatic logging defaults, and that `TIKA_CLIENT_ONLY` defaults to `true`.

### Testing
- Ran `python -m py_compile ephemeral_app.py` which completed successfully. 
- Attempted to run the PowerShell syntax/content check (`powershell -Command "Get-Content services/*.ps1 | Out-Null"`) but PowerShell is not available in this Linux CI environment so that check could not be executed here. 
- Verified the changes via static inspection of the updated PowerShell installer logic and documentation to ensure consistency with the intended Windows-first deployment flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdfe2ba448328974aef4e6f2db50a)