### PR TITLE
Clarify Ollama model directory alignment in deployment guide

### DIFF
--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -238,6 +238,14 @@ C:\EphemerAl\services\Check-EphemerAlServices.ps1
 
 Choose **one** path based on available VRAM.
 
+Before running any `ollama pull` or `ollama create` command in this phase, set the model directory for the current PowerShell session so manual model management matches the Windows service configuration:
+
+```powershell
+$env:OLLAMA_MODELS='C:\Ollama\models'
+```
+
+> **Why this matters:** The service installer configures `OllamaService` to use `C:\Ollama\models`. Setting this variable first prevents a common first-run issue where models are downloaded to a different default folder and then appear missing after service restart.
+
 ### Path A: Standard (GPU VRAM = 12GB+)
 *Best for RTX 3060, 4060 Ti, 5060 Ti, 3090, 4090.*
 


### PR DESCRIPTION
### Motivation

- Prevent a common first-run setup problem where `ollama` downloads models into a different default folder than the one the `OllamaService` expects, causing models to appear "missing" after a service restart.

### Description

- Added a pre-step to **Phase 6** of `System Deployment Guide.md` instructing operators to set the model directory in the current PowerShell session with ` $env:OLLAMA_MODELS='C:\Ollama\models'` and a short explanation of why this alignment matters.

### Testing

- Ran `python -m py_compile ephemeral_app.py`, which succeeded.
- Attempted to run the PowerShell syntax/read check (`powershell`/`pwsh` commands) but those binaries are not available in this Linux execution environment, so the PowerShell checks could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e72ad37488328a27b32e481fc48cb)