### PR TITLE
Fix Qwen 3.5 thinking-mode leakage in streaming UI and docs

### DIFF
--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -137,6 +137,7 @@ PARAMETER num_ctx 32768
 PARAMETER num_gpu 99
 PARAMETER temperature 0.7
 PARAMETER top_p 0.9
+SYSTEM "You are a helpful assistant. /no_think"
 EOF_MODEL
 ollama create ephemeral-default -f Modelfile
 exit
@@ -190,6 +191,7 @@ PARAMETER num_ctx 32768
 PARAMETER num_gpu 99
 PARAMETER temperature 0.7
 PARAMETER top_p 0.9
+SYSTEM "You are a helpful assistant. /no_think"
 EOF_MODEL
 ollama create ephemeral-default -f Modelfile
 exit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
     environment:
       - LLM_BASE_URL=http://ollama:11434/v1
       - LLM_MODEL_NAME=qwen3.5:35b-a3b     # CUSTOMIZE: Use an explicit Ollama model tag or your own local alias
+                                            # NOTE: Direct qwen3.5 tags enable thinking mode and may emit <think> blocks.
+                                            #       Recommended: create/use an alias (for example ephemeral-default) with /no_think in the Modelfile SYSTEM line.
       - TIKA_URL=http://tika-server:9998
       - TIKA_CLIENT_ONLY=true
       - STREAMLIT_SERVER_HEADLESS=true

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1229,12 +1229,42 @@ if prompt_in is not None:
                 acc = ""
                 box = st.empty()
                 used_usage_from_backend = False
+                in_think_block = False
+                stream_parse_buffer = ""
+                think_open_tag = "<think>"
+                think_close_tag = "</think>"
+                open_tag_tail_len = len(think_open_tag) - 1
+                close_tag_tail_len = len(think_close_tag) - 1
 
                 for chunk in stream:
                     if getattr(chunk, "choices", None):
                         delta = chunk.choices[0].delta.content
                         if delta:
-                            acc += delta
+                            stream_parse_buffer += delta
+
+                            while stream_parse_buffer:
+                                if in_think_block:
+                                    close_idx = stream_parse_buffer.find(think_close_tag)
+                                    if close_idx == -1:
+                                        if len(stream_parse_buffer) > close_tag_tail_len:
+                                            stream_parse_buffer = stream_parse_buffer[-close_tag_tail_len:]
+                                        break
+
+                                    stream_parse_buffer = stream_parse_buffer[close_idx + len(think_close_tag) :]
+                                    in_think_block = False
+                                    continue
+
+                                open_idx = stream_parse_buffer.find(think_open_tag)
+                                if open_idx == -1:
+                                    if len(stream_parse_buffer) > open_tag_tail_len:
+                                        acc += stream_parse_buffer[:-open_tag_tail_len]
+                                        stream_parse_buffer = stream_parse_buffer[-open_tag_tail_len:]
+                                    break
+
+                                acc += stream_parse_buffer[:open_idx]
+                                stream_parse_buffer = stream_parse_buffer[open_idx + len(think_open_tag) :]
+                                in_think_block = True
+
                             box.markdown(acc + "▌")
 
                     usage = getattr(chunk, "usage", None)
@@ -1242,6 +1272,10 @@ if prompt_in is not None:
                         st.session_state.last_token_count = int(usage.total_tokens)
                         used_usage_from_backend = True
 
+                if not in_think_block and stream_parse_buffer:
+                    acc += stream_parse_buffer
+
+                acc = re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)
                 box.markdown(acc)
 
                 # If backend didn't provide usage totals, keep hybrid behavior with a fast estimate.


### PR DESCRIPTION
### Motivation
- Qwen 3.5 defaults to a thinking mode that emits `<think>...</think>` blocks which can leak chain-of-thought into the streaming UI. 
- There is a known Ollama behavior where vision inputs may route content to a `thinking` field instead of `content`, causing empty or misrouted responses. 
- The deployment docs should recommend a safe alias that disables thinking at the model template level to avoid exposing internal reasoning.

### Description
- Added stateful streaming parsing in `ephemeral_app.py` that tracks `in_think_block` and uses a `stream_parse_buffer` to safely handle partial `<think>`/`</think>` tags across chunk boundaries. 
- The streaming loop now only appends non-think text to the visible accumulator and maintains the streaming cursor (`▌`) for user-visible content only. 
- Performed a final defensive cleanup with `re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)` before rendering and before storing the final assistant message in `st.session_state.messages`. 
- Updated both `Modelfile` examples in `System Deployment Guide.md` to append `SYSTEM "You are a helpful assistant. /no_think"` and added a comment in `docker-compose.yml` near `LLM_MODEL_NAME` recommending the alias approach and warning about direct `qwen3.5` thinking mode.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it completed successfully. 
- Ran `powershell -Command "Get-Content services/*.ps1 | Out-Null"` which failed in this Linux/container environment because PowerShell is not installed (expected in CI here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d329c1f4a48328a2287d78366c8f6f)