### PR TITLE
Post-migration cleanup for Qwen3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The app performs model capability/context detection at runtime via Ollama (`/api
 
 Qwen 3.5 35B is substantially heavier than small local models.
 
-- **Minimum practical GPU setup:** 24 GB+ total VRAM (single or multi-GPU), with reduced context if needed.
-- **Preferred for smoother latency and longer context:** 32 GB+ total VRAM.
+- **Recommended:** 32 GB+ total VRAM.
+- **Works for many users:** 24 GB total VRAM (usually with lower context).
 - **CPU-only fallback:** technically possible in some setups but usually too slow for interactive use.
 
 If this model is too heavy for your machine, use a smaller Ollama model tag in `LLM_MODEL_NAME`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
   # Large-language-model back-end (Ollama)
   # --------------------------------------------------------------------------
   ollama:
+    # Pinned for compatibility with qwen3.5 tags. Last validated: April 2026.
+    # Check https://github.com/ollama/ollama/releases before upgrading,
+    # especially for vision+thinking fixes (see ollama/ollama#14716).
     image: ollama/ollama:0.20.2
     container_name: ollama
     restart: unless-stopped
@@ -31,6 +34,7 @@ services:
       - OLLAMA_HOST=0.0.0.0
       - OLLAMA_ORIGINS=*
       - OLLAMA_MAX_LOADED_MODELS=1
+      # Carried over from Gemma setup; may not benefit Qwen3.5 MoE inference.
       - OLLAMA_FORCE_CUBLAS_LT=1
       - OLLAMA_KEEP_ALIVE=-1
       - OLLAMA_FLASH_ATTENTION=1

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -984,7 +984,9 @@ if prompt_in is not None:
         max_ctx = int(model_ctx * 0.95)
         warn_ctx = int(model_ctx * 0.85)
     else:
-        max_ctx = 128000
+        # Conservative fallback matching the recommended Modelfile num_ctx.
+        # Avoids overstuffing if /api/show is unreachable.
+        max_ctx = 32768
         warn_ctx = int(max_ctx * 0.85)
 
     image_token_cost = get_image_token_cost() if vision_supported else 0

--- a/system_prompt_template.md
+++ b/system_prompt_template.md
@@ -1,7 +1,7 @@
 ### 1. Core Identity
 You are a helpful and harmless AI assistant.  
 Current local time: ${current_time_local}  
-Knowledge and training cutoff: August 2024
+Knowledge and training cutoff: Late 2025
 
 ### 2. Guiding Principles (in order of priority)
 1. **Safety and Factuality** – Be helpful, harmless, and factual. If you're unsure, say so plainly. Do not invent information.  


### PR DESCRIPTION
### Motivation
- Align the system prompt and docs with the Qwen 3.5 migration to avoid incorrect model-date hedging and inconsistent operator guidance. 
- Prevent silent context overflows when Ollama `/api/show` is unreachable by using a conservative fallback context window that matches the recommended `Modelfile`.
- Make hardware guidance consistent between `README.md` and `System Deployment Guide.md` so operators get the same two-tier VRAM guidance.
- Annotate the pinned Ollama image and a legacy environment variable to help operators make informed upgrade decisions.

### Description
- Updated `system_prompt_template.md` to change the training cutoff line to `Knowledge and training cutoff: Late 2025`.
- Modified `ephemeral_app.py` to reduce the `get_model_ctx()` fallback `max_ctx` from `128000` to `32768` and added a brief comment explaining this conservative fallback and why it avoids overstuffing if `/api/show` is unreachable.
- Edited `README.md` hardware planning section to match the deployment guide wording: `**Recommended:** 32 GB+ total VRAM.` and `**Works for many users:** 24 GB total VRAM (usually with lower context).`.
- Updated `docker-compose.yml` to add a comment block above the pinned `image: ollama/ollama:0.20.2` explaining the pin (last validated April 2026) and to annotate `OLLAMA_FORCE_CUBLAS_LT=1` as carried over from Gemma and possibly not beneficial for Qwen3.5 MoE.

### Testing
- Ran `python -m py_compile ephemeral_app.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32b130d988328b56d126fce2c197c)