### PR TITLE
Ensure app-delivered system prompt always includes /no_think

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -179,6 +179,8 @@ def timestamp_local() -> str:
 
 tmpl_path = pathlib.Path(__file__).parent / "system_prompt_template.md"
 if tmpl_path.exists():
+    # Keep `/no_think` in the template itself so the app-sent system prompt
+    # always carries it; the streaming think-block filter is only a backup.
     SYSTEM_TMPL = string.Template(tmpl_path.read_text(encoding="utf-8"))
 else:
     SYSTEM_TMPL = string.Template(

--- a/system_prompt_template.md
+++ b/system_prompt_template.md
@@ -23,3 +23,5 @@ If the user's first message is very simple (e.g., "hi", "what can you do?"), you
 • Use Markdown when it improves readability (e.g., lists, bold headings).
 • Avoid tables unless requested, 
 • If you lack critical information, say what’s missing and suggest the next step.
+
+/no_think


### PR DESCRIPTION
### Motivation
- Ensure the `/no_think` directive is always present in the `role: system` prompt the app sends because the app supplies its own system message which can override the Modelfile `SYSTEM`, so placing the directive in the template provides defense-in-depth.

### Description
- Appended `/no_think` to the end of `system_prompt_template.md` and added a brief inline comment next to the `SYSTEM_TMPL` loading in `ephemeral_app.py` documenting that `/no_think` is kept in the template and the streaming think-block filter is only a backup.

### Testing
- Ran `python -m py_compile ephemeral_app.py` which succeeded, and attempted the Windows PowerShell syntax check `powershell -Command "Get-Content services/*.ps1 | Out-Null"` which could not be executed in this Linux CI environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32ee6046c8328a9c2483155e0b08e)