### PR TITLE
Handle Ollama reasoning fallback for Qwen3.5 vision streaming bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
   # --------------------------------------------------------------------------
   ollama:
     # Pinned for compatibility with qwen3.5 tags. Last validated: April 2026.
-    # Check https://github.com/ollama/ollama/releases before upgrading,
-    # especially for vision+thinking fixes (see ollama/ollama#14716).
+    # Check https://github.com/ollama/ollama/releases before upgrading.
+    # NOTE: ollama/ollama#14716 (vision+thinking) is still open as of 0.20.2.
     image: ollama/ollama:0.20.2
     container_name: ollama
     restart: unless-stopped

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1243,6 +1243,11 @@ if prompt_in is not None:
                 for chunk in stream:
                     if getattr(chunk, "choices", None):
                         delta = chunk.choices[0].delta.content
+                        if not delta:
+                            # Workaround for Ollama vision+thinking bug (ollama/ollama#14716, still open).
+                            # Through the OpenAI-compatible API, Ollama maps thinking output
+                            # to a non-standard `reasoning` field on the delta.
+                            delta = getattr(chunk.choices[0].delta, "reasoning", None)
                         if delta:
                             stream_parse_buffer += delta
 


### PR DESCRIPTION
### Motivation
- Fix streaming output loss when Ollama's vision+thinking bug emits text on a non-standard `reasoning` delta instead of `content` (see `ollama/ollama#14716`).
- Clarify `docker-compose.yml` comments to avoid implying the issue is already fixed for the pinned `0.20.2` image.

### Description
- Add a fallback in the stream parsing loop to read `getattr(chunk.choices[0].delta, 'reasoning', None)` when `delta.content` is empty so output still flows through the existing think-block filter. 
- Document the fallback inline as a workaround for `ollama/ollama#14716` in `ephemeral_app.py`. 
- Update the Ollama version comment in `docker-compose.yml` to state that `ollama/ollama#14716` remains open as of `0.20.2`.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it completed successfully. 
- Attempted the PowerShell syntax check `powershell -Command "Get-Content services/*.ps1 | Out-Null"`, but PowerShell is not available in this Linux CI environment so that check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32faff530832899b2362fbcdb76f3)