### PR TITLE
Handle unclosed <think> blocks at end-of-stream

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1281,8 +1281,14 @@ if prompt_in is not None:
                         st.session_state.last_token_count = int(usage.total_tokens)
                         used_usage_from_backend = True
 
-                if not in_think_block and stream_parse_buffer:
-                    acc += stream_parse_buffer
+                if in_think_block and DEBUG_MODE:
+                    logging.debug("Unclosed <think> block detected at end of stream.")
+
+                if stream_parse_buffer:
+                    if not in_think_block:
+                        acc += stream_parse_buffer
+                    elif not acc.strip():
+                        acc += stream_parse_buffer
 
                 acc = re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)
                 box.markdown(acc)


### PR DESCRIPTION
### Motivation
- Fix an edge case where a streaming assistant emits `<think>` but never `</think>`, causing `stream_parse_buffer` to be discarded and the user to see a blank response.
- Prefer showing raw reasoning to the user when the entire response is wrapped in an unclosed think block, and surface a debug log when this occurs.

### Description
- Add end-of-stream handling in `ephemeral_app.py` to log an unclosed think block when `in_think_block` is true and `DEBUG_MODE` is enabled via `logging.debug`.
- Preserve previous behavior by flushing `stream_parse_buffer` into `acc` when the stream ends outside a think block.
- If the stream ends inside an unclosed think block, flush `stream_parse_buffer` into `acc` only when `acc` is empty or whitespace-only, otherwise discard the trailing buffer; the existing post-stream cleanup with `re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)` remains unchanged.

### Testing
- Ran `python -m py_compile ephemeral_app.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d33076dd4c8328b5d3526e6bdbeb10)