### PR TITLE
Apply 5% fallback context margin and update Ollama #14716 comments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   ollama:
     # Pinned for compatibility with qwen3.5 tags. Last validated: April 2026.
     # Check https://github.com/ollama/ollama/releases before upgrading.
-    # NOTE: ollama/ollama#14716 (vision+thinking) is still open as of 0.20.2.
+    # NOTE: ollama/ollama#14716 (vision+thinking) is fixed; workaround retained as defense-in-depth.
     image: ollama/ollama:0.20.2
     container_name: ollama
     restart: unless-stopped

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -988,7 +988,7 @@ if prompt_in is not None:
     else:
         # Conservative fallback matching the recommended Modelfile num_ctx.
         # Avoids overstuffing if /api/show is unreachable.
-        max_ctx = 32768
+        max_ctx = int(32768 * 0.95)
         warn_ctx = int(max_ctx * 0.85)
 
     image_token_cost = get_image_token_cost() if vision_supported else 0
@@ -1244,7 +1244,7 @@ if prompt_in is not None:
                     if getattr(chunk, "choices", None):
                         delta = chunk.choices[0].delta.content
                         if not delta:
-                            # Workaround for Ollama vision+thinking bug (ollama/ollama#14716, still open).
+                            # Workaround for Ollama vision+thinking bug (ollama/ollama#14716, fixed; workaround retained as defense-in-depth).
                             # Through the OpenAI-compatible API, Ollama maps thinking output
                             # to a non-standard `reasoning` field on the delta.
                             delta = getattr(chunk.choices[0].delta, "reasoning", None)


### PR DESCRIPTION
### Motivation
- Ensure the conservative fallback context window uses the same 5% headroom as the normal `model_ctx` path to avoid overstuffing when `/api/show` is unreachable.
- Reflect that the Ollama vision+thinking bug (ollama/ollama#14716) has been fixed while keeping the existing workaround as defense-in-depth.

### Description
- In `ephemeral_app.py` replaced `max_ctx = 32768` with `max_ctx = int(32768 * 0.95)` so the fallback path applies the same 5% safety margin as the primary path.
- Updated the inline comment about the Ollama vision+thinking issue in `ephemeral_app.py` and the corresponding comment in `docker-compose.yml` to say the issue is "fixed; workaround retained as defense-in-depth." 

### Testing
- Ran `python -m py_compile ephemeral_app.py` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d334be77dc832887b3dc389e267155)