### PR TITLE
Fix Docker service-name defaults for backend URLs

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -83,10 +83,10 @@ except ImportError:
     device = None  # type: ignore
 
 # ── Backend configuration ─────────────────────────────────────────
-LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:11434/v1")
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
 # Default to the official Ollama model tag so installs work without a local alias.
 MODEL_NAME = os.getenv("LLM_MODEL_NAME", "qwen3.5:35b-a3b")
-TIKA_URL = os.getenv("TIKA_URL", "http://localhost:9998")
+TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")
 TIKA_TIMEOUT_S = int(os.getenv("TIKA_TIMEOUT_S", "15"))
 DEFAULT_UPLOAD_PROMPT = os.getenv("DEFAULT_UPLOAD_PROMPT", "Please analyze the uploaded files.")
 LLM_SUPPORTS_VISION = os.getenv("LLM_SUPPORTS_VISION")


### PR DESCRIPTION
### Motivation
- Restore Docker-appropriate fallback defaults because containers in Docker Compose resolve each other by service name, not `localhost`, and the accidental `localhost` defaults broke containerized deployments.

### Description
- Change only the two fallback default values in the backend configuration of `ephemeral_app.py` so `LLM_BASE_URL` defaults to `http://ollama:11434/v1` and `TIKA_URL` defaults to `http://tika-server:9998`, leaving `MODEL_NAME` and surrounding comments unchanged.

### Testing
- Run `python -m py_compile ephemeral_app.py` to verify syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47dcaf0e083288204213dd82e64d7)