### PR TITLE
Restore README restart, Support, and License wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ If your current stack still points at `gemma3-prod` (or another Gemma tag), use 
 
 Execute the following in an Administrator PowerShell window:
 
+To restart, either run `wsl` or reboot the system if you have the startup script installed.
+
 ## Support
 
-This project is shared as-is for local/private AI use cases.
+This project is provided as a resource for the community as-is. I hope it solves a problem or provides value outside my environment.
 
-If you run into issues, gather logs and screenshots and verify model availability in Ollama first.
+If you run into issues, consider submitting error details, including screenshots and system files, to an AI assistant for guidance. This isn't meant to be snark, it's amazing how well the big reasoning models can troubleshoot.
 
-## License
+**License:**
 
-MIT (for the parts of this repository authored by the project owner).
+MIT - (At least the parts of this stack that are mine to license)


### PR DESCRIPTION
### Motivation
- Restore the originally intended guidance and tone in the documentation by re-adding a restart hint in the "Stopping the Application" section, returning the Support section to a community-focused voice, and restoring the License formatting and wording.

### Description
- Update `README.md` to insert the restart line under "Stopping the Application", replace the Support paragraph with the requested community-oriented wording, and change the License heading and line to the prescribed formatting and text.

### Testing
- Verified the change set and file contents using `rg`/search, `nl -ba README.md | sed -n '96,125p'` and `git diff -- README.md`, and committed the modified `README.md` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d481b130ec83288dfe7175cb8b1066)