### PR TITLE
Replace AGENTS.md with Docker/WSL2 architecture instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,44 +1,64 @@
 # AGENTS.md
 
 ## Project Overview
-EphemerAl is a privacy-focused document chat application. It runs a Streamlit frontend
-that connects to an Ollama LLM backend and an Apache Tika document parsing server.
-All three services run natively on Windows (no Docker, no WSL).
+EphemerAl is a privacy-focused document chat application. It runs as a Docker Compose
+stack inside WSL2 (Ubuntu) on Windows. Three containers make up the stack: a Streamlit
+frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
 
 ## Architecture
 - **Streamlit app** (`ephemeral_app.py`): The web frontend. Connects to Ollama and Tika
-  via HTTP on localhost. Environment variables configure the endpoints.
-- **Ollama**: Serves the LLM. Runs natively on Windows with GPU support. API on port 11434.
-- **Apache Tika Server**: Parses documents. Runs as a Java JAR. API on port 9998.
-- **All three run as Windows services via NSSM** (Non-Sucking Service Manager) to survive
-  reboots without requiring user login.
+  via Docker service names over an internal Docker network. Environment variables configure
+  the endpoints.
+- **Ollama**: Serves the LLM inside a container with GPU passthrough. API on port 11434.
+- **Apache Tika Server**: Parses documents inside a container. API on port 9998.
+- **Docker Compose** (`docker-compose.yml`): Defines the full stack. Containers communicate
+  by Docker service name (`ollama`, `tika-server`) on a shared `llm-net` bridge network.
 
 ## Key Files
 - `ephemeral_app.py` — Main application. All state is in-memory (session_state).
-- `requirements.txt` — Python dependencies.
+- `docker-compose.yml` — Stack definition. Pins Ollama and Tika image versions.
+- `Dockerfile` — Builds the Streamlit app container image.
+- `requirements.txt` — Python dependencies (installed inside the app container).
 - `System Deployment Guide.md` — End-user deployment instructions (target audience: IT
-  generalists, not developers).
-- `system_prompt_template.md` — LLM system prompt template.
-- `.streamlit/config.toml` — Streamlit theme/config.
-- `theme.css` — Custom CSS.
+  generalists, not developers). Written for WSL2 + Docker on Windows 11.
+- `README.md` — Project overview, feature list, system requirements.
+- `system_prompt_template.md` — LLM system prompt template. Includes `/no_think` directive
+  for Qwen models.
+- `.streamlit/config.toml` — Streamlit theme and config. The Dockerfile merges server
+  settings into this file at build time.
+- `theme.css` — Custom CSS loaded by the app.
 - `static/` — Logo and static assets.
-- `services/` — PowerShell scripts for Windows service management.
 
 ## Conventions
 - The deployment guide is written for non-technical IT staff. Use plain language,
   avoid jargon, explain every step, and provide copy-pasteable commands.
-- Python code should work on Windows natively (no Linux-only paths or commands).
-- Environment variable defaults in ephemeral_app.py should point to localhost, not
-  Docker container names.
-- PowerShell scripts should be compatible with PowerShell 5.1+ (ships with Windows).
+- The app runs inside Docker. Environment variable defaults in `ephemeral_app.py` MUST
+  use Docker service names (`http://ollama:11434/v1` and `http://tika-server:9998`),
+  NOT `localhost`. Using localhost as defaults will break the Docker Compose deployment.
+- The default LLM model is `qwen3.5:35b-a3b`. The model tag is set via the
+  `LLM_MODEL_NAME` environment variable in `docker-compose.yml`.
+- The app detects model capabilities (vision support, context size) at runtime via
+  Ollama's `/api/show` endpoint, so it adapts to different models automatically.
+- Qwen models may emit `<think>...</think>` blocks during streaming. The app includes
+  a streaming filter that strips these. The system prompt template also includes
+  `/no_think` as a first line of defense.
 
 ## Testing
 - Verify Python syntax: `python -m py_compile ephemeral_app.py`
-- Verify PowerShell syntax: `powershell -Command "Get-Content services/*.ps1 | Out-Null"`
-- Verify Markdown renders correctly (no broken links or formatting).
+- Verify requirements install: `pip install -r requirements.txt && pip check`
+- Verify Markdown links resolve: all relative links in README.md and the deployment
+  guide should point to files that exist in the repo.
+- Full stack test: `docker compose up -d --build` inside WSL2, then access
+  `http://localhost:8501`.
 
 ## Do Not
-- Do not introduce Docker, WSL, or Linux dependencies.
-- Do not modify `system_prompt_template.md` or `theme.css` (unless fixing Windows
-  path compatibility).
-- Do not add new Python dependencies beyond what's in requirements.txt.
+- Do not change environment variable defaults in `ephemeral_app.py` to use `localhost`.
+  The defaults MUST remain Docker service names for container-to-container communication.
+- Do not remove Docker, WSL2, or Linux content from the deployment guide or README.
+  That is the supported deployment path.
+- Do not modify `system_prompt_template.md` unless changing the LLM's system behavior.
+- Do not add new Python dependencies beyond what's in `requirements.txt` without
+  documenting the reason.
+- Do not remove the `/no_think` directive from `system_prompt_template.md` or the
+  `<think>` block streaming filter from `ephemeral_app.py`. Both are required for
+  correct Qwen model output.


### PR DESCRIPTION
### Motivation
- Replace the previous Windows-native service guidance with an authoritative agent-facing description of the project's actual Docker Compose + WSL2 deployment architecture.
- Make the agent conventions explicit about container networking and environment variable defaults to avoid incorrect `localhost` assumptions.
- Document required behaviors for Qwen streaming output handling and the expected testing steps for a Docker-based deployment.

### Description
- Replaced the entire `AGENTS.md` file contents with new guidance describing a Docker Compose stack running inside WSL2 (Streamlit, Ollama, Apache Tika).
- Updated the Architecture and Key Files sections to reference `docker-compose.yml`, `Dockerfile`, and `README.md`, and to describe container-to-container communication by service name.
- Changed conventions to require `ephemeral_app.py` environment variable defaults use Docker service names (e.g., `http://ollama:11434/v1`) and documented the default LLM model and runtime capability detection via Ollama's `/api/show` endpoint.
- Added testing instructions for dependency installation and a full stack smoke test with `docker compose up -d --build`, and reiterated the `/no_think` and `<think>`-block handling requirements.

### Testing
- Confirmed the new `AGENTS.md` file exists at the repository root using `pwd` and `rg --files | rg '^AGENTS\.md$'`.
- Printed and inspected the updated file contents with `sed -n '1,260p' AGENTS.md` and `nl -ba AGENTS.md | sed -n '1,220p'` to verify the replacement text.
- No application-level automated tests (for example `python -m py_compile ephemeral_app.py`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4897b880483288ef3ba5a5b487c6a)