### PR TITLE
docs: include git and gpg in Phase 3 apt install command

### DIFF
--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -88,7 +88,7 @@ We will now install the software that manages the AI applications.
 
 3.  Install required utilities and enable auto-updates:
 ```bash
-    sudo apt install -y build-essential curl unattended-upgrades
+    sudo apt install -y build-essential curl git gpg unattended-upgrades
 ```
 ```bash
     sudo dpkg-reconfigure -plow unattended-upgrades


### PR DESCRIPTION
### Motivation
- Prevent a later "command not found" failure by ensuring `git` and `gpg` are explicitly installed in Phase 3 so subsequent `git clone` and NVIDIA key import steps work on fresh Ubuntu installs.

### Description
- Updated the single line in `System Deployment Guide.md` (Phase 3, step 3) to `sudo apt install -y build-essential curl git gpg unattended-upgrades`.

### Testing
- Ran an automated replacement check that enforces exactly one substitution, verified the old line is absent and the new line appears with a pattern search, and printed the affected lines with line numbers; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48ab633348328893f1e50568ac80a)