### PR TITLE
Merge Streamlit server defaults into existing config and add network security note

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # --- Application code --------------------------------------------
 COPY . .
 # --- Streamlit config --------------------------------------------
-RUN mkdir -p .streamlit && cat > .streamlit/config.toml <<'EOF'
+RUN mkdir -p .streamlit && \
+    { cat <<'EOF_SERVER'
 [server]
 headless = true
 enableCORS = false
@@ -27,9 +28,9 @@ serverAddress     = "0.0.0.0"
 serverPort        = 8501
 gatherUsageStats  = false
 
-[theme]
-base = "light"
-EOF
+EOF_SERVER
+    cat .streamlit/config.toml; } > .streamlit/config.toml.merged && \
+    mv .streamlit/config.toml.merged .streamlit/config.toml
 
 EXPOSE 8501
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ EphemerAl is designed to minimize data retention:
 
 Note that browser caching behavior depends on your browser settings and cache-control headers. For maximum privacy on shared machines, use private/incognito browsing or clear browser data after use.
 
+## Network Security Note
+
+EphemerAl is designed for trusted local networks (home, office LAN) and does not implement authentication or transport encryption. The Streamlit container disables CORS and XSRF protection to allow straightforward LAN access. Do not expose this application to the public internet without adding a reverse proxy with authentication and TLS.
+
 ## Technical Stack
 
 - Python 3.11 + Streamlit


### PR DESCRIPTION
### Motivation

- Ensure the Streamlit server configuration is applied while preserving any existing user-configured `.streamlit/config.toml` entries.
- Clarify deployment guidance by warning that the app is intended for trusted local networks and lacks built-in authentication or TLS.

### Description

- Update `Dockerfile` to write a `server` block into `.streamlit/config.toml` using a grouped shell snippet that concatenates the generated server settings with any existing `.streamlit/config.toml` into a temporary merged file and then moves it into place.
- Keep the container's port exposed (`EXPOSE 8501`) and the same `CMD` to run the Streamlit app unchanged.
- Add a `Network Security Note` to `README.md` that explicitly warns about disabled CORS/XSRF protections and recommends using a reverse proxy with authentication and TLS before exposing the app publicly.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48b615bac8328b0e02ce603ea08ab)