### PR TITLE
Support Gemma 4 fallback and disable Ollama auto-thinking on OpenAI endpoint

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -179,8 +179,8 @@ def timestamp_local() -> str:
 
 tmpl_path = pathlib.Path(__file__).parent / "system_prompt_template.md"
 if tmpl_path.exists():
-    # Load the prompt template from disk; the streaming think-block filter remains
-    # as defense-in-depth regardless of model-specific prompt tokens.
+    # Gemma 4 thinking is controlled via reasoning_effort in the API call,
+    # not via template tokens. The streaming think-block filter is defense-in-depth.
     SYSTEM_TMPL = string.Template(tmpl_path.read_text(encoding="utf-8"))
 else:
     SYSTEM_TMPL = string.Template(
@@ -1205,6 +1205,9 @@ if prompt_in is not None:
         with st.spinner("Thinking…"):
             try:
                 client = get_llm_client()
+                # Disable Ollama auto-thinking via reasoning_effort on the OpenAI-compat endpoint.
+                # See: https://github.com/ollama/ollama/issues/14820
+                _extra = {"reasoning_effort": "none"}
 
                 # Try include_usage if supported, fall back otherwise.
                 try:
@@ -1213,12 +1216,14 @@ if prompt_in is not None:
                         messages=payload,
                         stream=True,
                         stream_options={"include_usage": True},
+                        extra_body=_extra,
                     )
                 except TypeError:
                     stream = client.chat.completions.create(
                         model=MODEL_NAME,
                         messages=payload,
                         stream=True,
+                        extra_body=_extra,
                     )
                 except Exception as e:
                     if "stream_options" in str(e) or "include_usage" in str(e):
@@ -1226,6 +1231,7 @@ if prompt_in is not None:
                             model=MODEL_NAME,
                             messages=payload,
                             stream=True,
+                            extra_body=_extra,
                         )
                     else:
                         raise


### PR DESCRIPTION
### Motivation
- Default the runtime LLM to Gemma 4 so the app uses `gemma4:31b` when no `LLM_MODEL_NAME` is set. 
- Disable Ollama’s auto-thinking behavior on the OpenAI-compatible endpoint by setting the API reasoning control instead of relying on prompt tokens. 
- Retain the existing streaming `<think>` block filter as defense-in-depth in case model output still emits thinking markers. 

### Description
- Change the default model fallback to `gemma4:31b` via `MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemma4:31b")`.
- Update the system-prompt template comment to state that Gemma 4 thinking is controlled via `reasoning_effort` rather than template tokens. 
- Add `_extra = {"reasoning_effort": "none"}` immediately before the streaming `client.chat.completions.create()` calls and include the Ollama issue reference in the comment. 
- Pass `extra_body=_extra` to all three `client.chat.completions.create()` calls in the streaming `try/except` cascade (primary call with `stream_options`, the `TypeError` fallback, and the generic `Exception` fallback). 

### Testing
- Ran `python -m py_compile ephemeral_app.py`, which completed successfully. 
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ee9450288328b74aebf5c2d7f679)