### PR TITLE
Fix first-turn uploads and text-only payload compatibility for Ollama/Gemma4

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -948,13 +948,10 @@ if HAS_DEVICE_DETECTION and device and device.is_mobile:
 
 # ── Chat input ───────────────────────────────────────────────────
 prompt_in = st.chat_input("Ask me anything…", accept_file="multiple", key="main_chat")
-prompt_in = st.session_state.pop("_first_prompt_pending", None) or prompt_in
 
 if prompt_in is not None:
     if st.session_state.show_welcome:
         st.session_state.show_welcome = False
-        st.session_state["_first_prompt_pending"] = prompt_in
-        st.rerun()
 
     user_text = prompt_in.text if hasattr(prompt_in, "text") else prompt_in
     user_text = (user_text or "").strip()
@@ -1189,9 +1186,17 @@ if prompt_in is not None:
                     if vision_supported:
                         api_parts.append(part)
 
-            # Avoid sending empty content arrays (some backends reject them).
+            # Some backends/models are stricter about content arrays:
+            # - If all parts are text, send a plain string.
+            # - If no parts remain, send a text placeholder instead of an empty array.
             if not api_parts:
-                api_parts = [{"type": "text", "text": "(Attachment omitted.)"}]
+                messages_for_api.append({"role": msg["role"], "content": "(Attachment omitted.)"})
+                continue
+
+            if all(part.get("type") == "text" for part in api_parts):
+                combined_text = "\n\n".join(part.get("text", "") for part in api_parts).strip()
+                messages_for_api.append({"role": msg["role"], "content": combined_text or "(Attachment omitted.)"})
+                continue
 
             messages_for_api.append({"role": msg["role"], "content": api_parts})
         else:


### PR DESCRIPTION
### Motivation
- Users reported uploaded document text not reaching the model (notably after moving to Gemma4), likely due to first-turn handling and stricter backend expectations for message payloads.
- The welcome-screen rerun flow could defer the initial `st.chat_input` payload and risk losing attached file objects on the first send.
- Some OpenAI-compatible backends/models appear to mishandle `content` arrays that contain only text parts, so text-only structured messages should be sent as plain strings for compatibility.

### Description
- Removed the welcome rerun handoff that stored the initial `st.chat_input` payload in session state so first-turn uploads are processed immediately (`ephemeral_app.py` chat input handling).
- Normalized `messages_for_api` serialization to collapse text-only `content` arrays into a single string while preserving multimodal arrays for image turns (`ephemeral_app.py` API payload construction).
- When no API parts remain, send a safe text placeholder (`"(Attachment omitted.)"`) instead of an empty array to avoid backend rejection.
- Kept existing vision/image handling and hybrid token-estimate behavior unchanged while adding explanatory comments for compatibility reasons.

### Testing
- Ran `python -m py_compile ephemeral_app.py` (ran twice) and it completed successfully with no syntax errors.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71f33b6548328a06a04e7f486eaed)