### PR TITLE
Support Gemma 4 thought-channel tags in streaming think-block filter

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1245,11 +1245,18 @@ if prompt_in is not None:
                 box = st.empty()
                 used_usage_from_backend = False
                 in_think_block = False
+                current_think_close_tag = ""
                 stream_parse_buffer = ""
-                think_open_tag = "<think>"
-                think_close_tag = "</think>"
-                open_tag_tail_len = len(think_open_tag) - 1
-                close_tag_tail_len = len(think_close_tag) - 1
+                # Filter both legacy (<think>...</think>) and Gemma 4
+                # (<|channel|>thought\n...<channel|>) think-block formats.
+                think_tag_pairs = [
+                    ("<|channel|>thought\n", "<channel|>"),
+                    ("<think>", "</think>"),
+                ]
+                open_tag_tail_len = max(len(open_tag) for open_tag, _ in think_tag_pairs) - 1
+                close_tag_tail_lens = {
+                    close_tag: len(close_tag) - 1 for _, close_tag in think_tag_pairs
+                }
 
                 for chunk in stream:
                     if getattr(chunk, "choices", None):
@@ -1264,26 +1271,39 @@ if prompt_in is not None:
 
                             while stream_parse_buffer:
                                 if in_think_block:
-                                    close_idx = stream_parse_buffer.find(think_close_tag)
+                                    close_idx = stream_parse_buffer.find(current_think_close_tag)
                                     if close_idx == -1:
+                                        close_tag_tail_len = close_tag_tail_lens[current_think_close_tag]
                                         if len(stream_parse_buffer) > close_tag_tail_len:
                                             stream_parse_buffer = stream_parse_buffer[-close_tag_tail_len:]
                                         break
 
-                                    stream_parse_buffer = stream_parse_buffer[close_idx + len(think_close_tag) :]
+                                    stream_parse_buffer = stream_parse_buffer[
+                                        close_idx + len(current_think_close_tag) :
+                                    ]
                                     in_think_block = False
+                                    current_think_close_tag = ""
                                     continue
 
-                                open_idx = stream_parse_buffer.find(think_open_tag)
-                                if open_idx == -1:
+                                nearest_open = None
+                                for open_tag, close_tag in think_tag_pairs:
+                                    open_idx = stream_parse_buffer.find(open_tag)
+                                    if open_idx == -1:
+                                        continue
+                                    if nearest_open is None or open_idx < nearest_open[0]:
+                                        nearest_open = (open_idx, open_tag, close_tag)
+
+                                if nearest_open is None:
                                     if len(stream_parse_buffer) > open_tag_tail_len:
                                         acc += stream_parse_buffer[:-open_tag_tail_len]
                                         stream_parse_buffer = stream_parse_buffer[-open_tag_tail_len:]
                                     break
 
+                                open_idx, open_tag, close_tag = nearest_open
                                 acc += stream_parse_buffer[:open_idx]
-                                stream_parse_buffer = stream_parse_buffer[open_idx + len(think_open_tag) :]
+                                stream_parse_buffer = stream_parse_buffer[open_idx + len(open_tag) :]
                                 in_think_block = True
+                                current_think_close_tag = close_tag
 
                             box.markdown(acc + "▌")
 
@@ -1293,7 +1313,7 @@ if prompt_in is not None:
                         used_usage_from_backend = True
 
                 if in_think_block and DEBUG_MODE:
-                    logging.debug("Unclosed <think> block detected at end of stream.")
+                    logging.debug("Unclosed think block detected at end of stream.")
 
                 if stream_parse_buffer:
                     if not in_think_block:
@@ -1301,6 +1321,7 @@ if prompt_in is not None:
                     elif not acc.strip():
                         acc += stream_parse_buffer
 
+                acc = re.sub(r"<\|channel\|>thought\n.*?<channel\|>\s*", "", acc, flags=re.DOTALL)
                 acc = re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)
                 box.markdown(acc)
 


### PR DESCRIPTION
### Motivation
- The streaming filter previously only matched legacy `<think>...</think>` tags but the backend model now uses Gemma 4 which emits `<|channel|>thought\n...<channel|>` thinking blocks. 
- The change ensures thinking output is not leaked to users when Gemma 4 emits thought-channel blocks that may arrive split across stream chunks. 
- Maintain the existing defense-in-depth behavior for other models and past Ollama leaks while adapting to the new tag format. 

### Description
- Extended the streaming parser to recognize both formats by introducing `think_tag_pairs` with `("<|channel|>thought\n", "<channel|>")` and `("<think>", "</think>")` and tracking the matching close tag per open. 
- Chose the nearest opening tag in the parse buffer, preserved per-tag tail buffer sizing to handle partial tags across stream chunks, and maintained `in_think_block` semantics and unclosed-block handling. 
- Added `current_think_close_tag` bookkeeping and adjusted buffer slicing so close tags are removed safely when they span chunks. 
- Updated post-stream cleanup to run `re.sub` for both Gemma 4 and legacy formats and refreshed comments to document the dual-format defense-in-depth filtering. 

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it succeeded. 
- No additional automated tests were modified or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72b3105c48328bb7d35ee41037eab)