### PR TITLE
Set Gemma 4 fallback image token cost to 1120

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -32,8 +32,9 @@ CONTEXT_PREFIX = "Context:\n"
 # TTL for session-scoped Tika parse cache (seconds)
 TIKA_CACHE_TTL_S = 3600
 
-# Default approximation for a single image input (overridden if model metadata provides a value)
-IMG_TOKEN_COST_DEFAULT = 2048
+# Fallback per-image token cost for Gemma 4 vision when /api/show has no mm.tokens_per_image;
+# Gemma 4 uses discrete budgets (70/140/280/560/1120), so default to conservative max budget.
+IMG_TOKEN_COST_DEFAULT = 1120
 
 # Token estimation behavior
 TOKEN_HEURISTIC_CHARS_PER_TOKEN = 3.5


### PR DESCRIPTION
### Motivation
- `IMG_TOKEN_COST_DEFAULT` was set to an invalid Gemma 4 budget (`2048`), so use a conservative valid Gemma 4 per-image token budget (`1120`) as the fallback when `/api/show` does not report `mm.tokens_per_image` to avoid underestimating context usage.

### Description
- Changed the `IMG_TOKEN_COST_DEFAULT` constant in `ephemeral_app.py` to `1120` and updated the inline comment to note Gemma 4's discrete visual token budgets (`70/140/280/560/1120`) and the rationale for choosing the conservative maximum as a fallback.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72bd5ec848328897612017453f56a)