### PR TITLE
Clarify Gemma 4 context fallback rationale

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -984,8 +984,9 @@ if prompt_in is not None:
         max_ctx = int(model_ctx * 0.95)
         warn_ctx = int(model_ctx * 0.85)
     else:
-        # Conservative fallback matching the recommended Modelfile num_ctx.
-        # Avoids overstuffing if /api/show is unreachable.
+        # Conservative Gemma 4 fallback when /api/show metadata is unavailable.
+        # Uses a likely Ollama runtime default num_ctx (32K), not Gemma 4 31B's
+        # theoretical 256K maximum, to avoid overstuffing prompts on lower-VRAM setups.
         max_ctx = int(32768 * 0.95)
         warn_ctx = int(max_ctx * 0.85)
 


### PR DESCRIPTION
### Motivation
- Update the inline rationale for the context-window fallback to reflect that the app now targets Gemma 4 31B and that the `32768` fallback is a conservative Ollama runtime assumption rather than a statement about the model's 256K theoretical maximum.

### Description
- Edited the comment in `ephemeral_app.py` at the context calculation branch to explicitly reference Gemma 4 and explain that the fallback uses a likely Ollama `num_ctx` default (~32K) to avoid overstuffing on lower-VRAM setups, while leaving the fallback value unchanged.

### Testing
- Ran `python -m py_compile ephemeral_app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72d4564b08328b732cfddef3cf366)