### PR TITLE
Remove vestigial `reasoning_effort` override for Gemma 4

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -180,8 +180,9 @@ def timestamp_local() -> str:
 
 tmpl_path = pathlib.Path(__file__).parent / "system_prompt_template.md"
 if tmpl_path.exists():
-    # Gemma 4 thinking is controlled via reasoning_effort in the API call,
-    # not via template tokens. The streaming think-block filter is defense-in-depth.
+    # Gemma 4 thinking is controlled by the <|think|> token in the system prompt.
+    # Our template omits that token, so thinking is off by default; the streaming
+    # think-block filter remains as defense-in-depth.
     SYSTEM_TMPL = string.Template(tmpl_path.read_text(encoding="utf-8"))
 else:
     SYSTEM_TMPL = string.Template(
@@ -1212,9 +1213,8 @@ if prompt_in is not None:
         with st.spinner("Thinking…"):
             try:
                 client = get_llm_client()
-                # Disable Ollama auto-thinking via reasoning_effort on the OpenAI-compat endpoint.
-                # See: https://github.com/ollama/ollama/issues/14820
-                _extra = {"reasoning_effort": "none"}
+                # Gemma 4 thinking is controlled by <|think|> in the system prompt;
+                # this template omits it, so no reasoning_effort override is sent.
 
                 # Try include_usage if supported, fall back otherwise.
                 try:
@@ -1223,14 +1223,12 @@ if prompt_in is not None:
                         messages=payload,
                         stream=True,
                         stream_options={"include_usage": True},
-                        extra_body=_extra,
                     )
                 except TypeError:
                     stream = client.chat.completions.create(
                         model=MODEL_NAME,
                         messages=payload,
                         stream=True,
-                        extra_body=_extra,
                     )
                 except Exception as e:
                     if "stream_options" in str(e) or "include_usage" in str(e):
@@ -1238,7 +1236,6 @@ if prompt_in is not None:
                             model=MODEL_NAME,
                             messages=payload,
                             stream=True,
-                            extra_body=_extra,
                         )
                     else:
                         raise


### PR DESCRIPTION
### Motivation
- The code previously sent an Ollama-specific `reasoning_effort` override with every chat call as a Gemma 3 workaround, which is now vestigial after switching to Gemma 4. 
- Sending undocumented parameters to an evolving API is a latent risk, and the system prompt template already controls Gemma 4 thinking via the `<|think|>` token (which this template omits). 

### Description
- Removed the `extra_body={"reasoning_effort": "none"}` usage from OpenAI-compatible `client.chat.completions.create` calls so the undocumented parameter is no longer sent. 
- Updated the system-prompt loading comment to state that Gemma 4 thinking is controlled by the `<|think|>` token and that the template omits it, so thinking is off by default; the streaming think-block filter is retained as defense-in-depth. 
- Left the API call flow and streaming logic unchanged aside from removing the extra parameter and its related comment. 

### Testing
- Ran `python -m py_compile ephemeral_app.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72de925488328ab8ec394656fa1e3)