### PR TITLE
Fix Gemma 4 thinking open-tag delimiter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
 - The app detects model capabilities (vision support, context size) at runtime via
   Ollama's `/api/show` endpoint, so it adapts to different models automatically.
 - Gemma 4 models may emit thought-channel blocks during streaming in the
-  `<|channel|>thought\n...<channel|>` format. The app includes a streaming filter
+  `<|channel>thought\n...<channel|>` format. The app includes a streaming filter
   that strips these, and thinking is controlled by the `<|think|>` token in the
   system prompt.
 
@@ -62,4 +62,4 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
   documenting the reason.
 - Do not remove Gemma 4 thinking guidance from `system_prompt_template.md` or the
   thought-channel streaming filter from `ephemeral_app.py`. Both are required for
-  correct Gemma 4 model output (including `<|channel|>thought\n...<channel|>` blocks).
+  correct Gemma 4 model output (including `<|channel>thought\n...<channel|>` blocks).

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1247,9 +1247,9 @@ if prompt_in is not None:
                 current_think_close_tag = ""
                 stream_parse_buffer = ""
                 # Filter both legacy (<think>...</think>) and Gemma 4
-                # (<|channel|>thought\n...<channel|>) think-block formats.
+                # (<|channel>thought\n...<channel|>) think-block formats.
                 think_tag_pairs = [
-                    ("<|channel|>thought\n", "<channel|>"),
+                    ("<|channel>thought\n", "<channel|>"),
                     ("<think>", "</think>"),
                 ]
                 open_tag_tail_len = max(len(open_tag) for open_tag, _ in think_tag_pairs) - 1
@@ -1320,7 +1320,7 @@ if prompt_in is not None:
                     elif not acc.strip():
                         acc += stream_parse_buffer
 
-                acc = re.sub(r"<\|channel\|>thought\n.*?<channel\|>\s*", "", acc, flags=re.DOTALL)
+                acc = re.sub(r"<\|channel>thought\n.*?<channel\|>\s*", "", acc, flags=re.DOTALL)
                 acc = re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)
                 box.markdown(acc)
 


### PR DESCRIPTION
### Motivation
- Correct the mistaken Gemma 4 thought-channel opening delimiter so streaming thought blocks are recognized and stripped consistently (the opening tag should be `"<|channel>thought\n"`, not `"<|channel|>thought\n"`).

### Description
- Replace the incorrect open tag with the correct `"<|channel>thought\n"` in the streaming filter `think_tag_pairs`, update the post-stream cleanup regex to `r"<\|channel>thought\n.*?<channel\|>\s*"`, and update the two occurrences in `AGENTS.md` to match the corrected open-tag form.

### Testing
- Ran `python -m py_compile ephemeral_app.py` which succeeded, and ran `grep -n 'channel|>' ephemeral_app.py AGENTS.md` to verify only the corrected open tag (`<|channel>`) and the existing close tag (`<channel|>`) remain, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7303a1efc8328b790b21c94f1ed40)