### PR TITLE
Harden compose networking for Ollama and Tika services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,9 @@ services:
       - OLLAMA_KEEP_ALIVE=-1
       - OLLAMA_FLASH_ATTENTION=1
 
-    # Expose Ollama's API port to the host
-    ports: ["11434:11434"]
+    # Intentionally internal-only on llm-net for privacy; temporarily switch to
+    # ports: ["11434:11434"] for local host debugging with curl if needed.
+    expose: ["11434"]
 
     # GPU reservation for Docker Compose v3+
     deploy:
@@ -66,7 +67,9 @@ services:
     networks: [llm-net]
     environment:
       - JAVA_TOOL_OPTIONS=-Xmx2g -Xms512m
-    ports: ["9998:9998"]
+    # Intentionally internal-only on llm-net for privacy; temporarily switch to
+    # ports: ["9998:9998"] for local host debugging with curl if needed.
+    expose: ["9998"]
 
     # Keep /tmp in RAM so uploaded docs never touch disk inside the container
     tmpfs:


### PR DESCRIPTION
### Motivation
- Ollama and Apache Tika were published to the host via `ports`, which exposes unauthenticated LLM and parsing endpoints and undermines the privacy-focused design. 
- These services only need container-to-container access on the internal `llm-net` bridge, so host-published ports are unnecessary and risky.

### Description
- Replaced `ports: ["11434:11434"]` for the `ollama` service with `expose: ["11434"]` and added a comment noting the intent and how to temporarily switch back to `ports` for local `curl` debugging.  
- Replaced `ports: ["9998:9998"]` for the `tika-server` service with `expose: ["9998"]` and added the same internal-only/debug comment.  
- Left the `ephemeral-app` `ports` directive unchanged so the Streamlit UI remains accessible from the host.  
- Committed the updated `docker-compose.yml` with these changes.

### Testing
- Ran a grep check `rg -n '^\s+ports:|^\s+expose:' docker-compose.yml` to verify the file now uses `expose` for `ollama` and `tika-server` and `ports` only for `ephemeral-app`, which succeeded.  
- Attempted `docker compose config` to validate the compose file but the Docker CLI was unavailable in the environment (`docker: command not found`), so runtime validation could not be completed.  
- Attempted a YAML parse with Python to inspect service keys but the `yaml` module was not installed in the environment, so that automated parse did not run to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d734839b2883289203fde7dbb9fc86)