### PR TITLE
Add Ollama KV cache quantization env var (q8_0)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - OLLAMA_FORCE_CUBLAS_LT=1
       - OLLAMA_KEEP_ALIVE=-1
       - OLLAMA_FLASH_ATTENTION=1
+      - OLLAMA_KV_CACHE_TYPE=q8_0          # Q8 KV cache: ~50% VRAM savings vs f16 default; requires FLASH_ATTENTION=1 above.
 
     # Intentionally internal-only on llm-net for privacy; temporarily switch to
     # ports: ["11434:11434"] for local host debugging with curl if needed.


### PR DESCRIPTION
### Motivation
- Reduce KV cache VRAM usage by enabling Ollama KV cache quantization to `q8_0`, which requires `OLLAMA_FLASH_ATTENTION=1`.

### Description
- Inserted `- OLLAMA_KV_CACHE_TYPE=q8_0          # Q8 KV cache: ~50% VRAM savings vs f16 default; requires FLASH_ATTENTION=1 above.` immediately after `- OLLAMA_FLASH_ATTENTION=1` in the `ollama` service `environment:` block in `docker-compose.yml` and made no other edits to the file.

### Testing
- Verified the change with `git diff -- docker-compose.yml`, confirmed the two environment lines appear in order via `sed -n '30,48p' docker-compose.yml`, and committed the change with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d73c32044c832899348436b1594fd2)