### PR TITLE
Align Gemma 4 default model and Ollama 0.20.4 pin across compose and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EphemerAl: A Simple Self-Hosted Chat Interface for Local AI with Ollama that Accepts Documents and Images
 
-EphemerAl is a lightweight, open-source web interface for interacting with local LLMs on your hardware via Ollama. I designed it for my day job to help keep our team's sensitive info off cloud services, and to provide a modern AI experience to staff without the per-user cost required to achieve equivalent capabilities online. The repository now defaults to Qwen 3.5 35B, but can be retargeted to any Ollama model by changing one environment variable (`LLM_MODEL_NAME`).
+EphemerAl is a lightweight, open-source web interface for interacting with local LLMs on your hardware via Ollama. I designed it for my day job to help keep our team's sensitive info off cloud services, and to provide a modern AI experience to staff without the per-user cost required to achieve equivalent capabilities online. The repository now defaults to Gemma 4 31B, but can be retargeted to any Ollama model by changing one environment variable (`LLM_MODEL_NAME`).
 
 While it wasn't built for broad distribution, I'm sharing this generalized version in case it helps others looking for a local-only, account-free, multimodal LLM interface. . . whether to provide an operational tool, a staff learning environment, or bragging rights when friends visit on your home network.
 
@@ -23,8 +23,8 @@ While it wasn't built for broad distribution, I'm sharing this generalized versi
 
 ### Default target
 
-- **Model:** Qwen 3.5 35B
-- **Ollama tag:** `qwen3.5:35b-a3b`
+- **Model:** Gemma 4 31B
+- **Ollama tag:** `gemma4:31b`
 
 ### Retarget to a different model
 
@@ -56,11 +56,11 @@ EphemerAl is designed for trusted local networks (home, office LAN) and does not
 - Ollama API (OpenAI-compatible endpoint for chat)
 - Apache Tika server
 - Docker Compose (for the included deployment path)
-- Pinned Ollama container image in compose: `ollama/ollama:0.20.2`
+- Pinned Ollama container image in compose: `ollama/ollama:0.20.4`
 
 ## Hardware Planning (honest baseline)
 
-Qwen 3.5 35B is substantially heavier than small local models.
+Gemma 4 31B is substantially heavier than small local models.
 
 - **Recommended:** 32 GB+ total VRAM.
 - **Works for many users:** 24 GB total VRAM (usually with lower context).
@@ -73,7 +73,7 @@ If this model is too heavy for your machine, use a smaller Ollama model tag in `
 To run this interface effectively, the following specifications are recommended.
 
 - **Operating System:** Windows 11 Pro or Enterprise, fully updated. WSL will be installed as part of setup (if not already present).
-- **Graphics Processing Unit:** One or more discrete NVIDIA GPU(s), preferably from the 30-series or later. Qwen 3.5 35B benefits from 24GB+ VRAM; 32GB+ recommended for full context.
+- **Graphics Processing Unit:** One or more discrete NVIDIA GPU(s), preferably from the 30-series or later. Gemma 4 31B benefits from 24GB+ VRAM; 32GB+ recommended for full context.
 - **Nvidia Driver:** The most recent WHQL-certified NVIDIA GPU driver. Optional components may be omitted.
 - **Additional Note:** If available, connect display to integrated graphics to allocate more VRAM to the NVIDIA GPU(s).
 
@@ -85,10 +85,10 @@ Use the step-by-step guide:
 
 ### Migrating an existing Gemma-based install
 
-If your current stack still points at `gemma3-prod` (or another Gemma tag), use the migration section in the deployment guide to switch to either:
+If your current stack still points at an older Gemma tag (for example `gemma3-prod`), use the migration section in the deployment guide to move forward to Gemma 4 by switching to either:
 
-- `LLM_MODEL_NAME=qwen3.5:35b-a3b` directly, or
-- a neutral local alias like `ephemeral-default` that maps to `qwen3.5:35b-a3b`.
+- `LLM_MODEL_NAME=gemma4:31b` directly, or
+- a neutral local alias like `ephemeral-default` that maps to `gemma4:31b`.
 
 ## Accessing EphemerAl
 

--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -208,11 +208,7 @@ git clone https://github.com/eowensai/EphemerAl.git ~/ephemeral-llm
 cd ~/ephemeral-llm
 ```
 
-The docker-compose.yml ships with `LLM_MODEL_NAME=ephemeral-default`, which expects a local model alias. For the simplest first-run experience, change this to use the Gemma 4 tag directly:
-
-```bash
-sed -i 's#LLM_MODEL_NAME=ephemeral-default#LLM_MODEL_NAME=gemma4:31b#' docker-compose.yml
-```
+The `docker-compose.yml` file already ships with `LLM_MODEL_NAME=gemma4:31b`, so no model-name change is needed for a standard first run.
 
 Now start the stack:
 
@@ -326,9 +322,9 @@ Every `wsl` call in this script explicitly targets `Ubuntu-24.04` with `-d`. Thi
 If the page works locally but not from another device, confirm your Windows network profile is set to **Private** (Settings → Network & Internet → your connection → Network profile type → Private), and verify the firewall rule from Step 6a was created successfully by running `Get-NetFirewallRule -DisplayName "EphemerAl*"` in PowerShell.
 
 
-## Optional: Stable Local Alias
+## Optional (Advanced/Operator): Stable Local Alias
 
-For users who want more control over model parameters, you can create a local alias that pins specific settings. This is useful if you want to lock the context window to a predictable size, enable or disable thinking mode explicitly, or insulate the app from upstream changes to the Ollama model tag.
+For operators who want more control over model parameters, you can create a local alias that pins specific settings. This is optional and not required for normal deployments. It is useful if you want to lock the context window to a predictable size, enable or disable thinking mode explicitly, or insulate the app from upstream changes to the Ollama model tag.
 
 Enter the Ollama container:
 
@@ -365,4 +361,3 @@ Some notes on the parameters in this Modelfile:
 - **num_ctx 4000** pins the context window to 4,000 tokens regardless of your VRAM. This is a conservative choice for predictable memory usage. Ollama's default auto-scaling would give you 32k on a 24–48 GB card, or 256k at 48+ GB. If you have VRAM headroom and want longer conversations or larger document uploads, increase this value or remove the line to let Ollama auto-scale.
 - **num_gpu 99** tells Ollama to offload as many layers as possible to the GPU.
 - **SYSTEM line** omits the `<|think|>` token, which tells Gemma 4 not to use extended reasoning. To enable thinking mode, change the line to: `SYSTEM "<|think|>\nYou are a helpful assistant."`. Be aware that thinking mode increases response time and VRAM usage, and the app's streaming filter will strip thought blocks from the displayed output.
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
     environment:
       - LLM_BASE_URL=http://ollama:11434/v1
-      - LLM_MODEL_NAME=ephemeral-default   # CUSTOMIZE: Recommended default alias (stable target if upstream tags change)
+      - LLM_MODEL_NAME=gemma4:31b          # CUSTOMIZE: Change to any Ollama tag or local alias if needed.
                                             # NOTE: Gemma 4 does not use /no_think. Thinking is controlled by the <|think|> token in the system prompt.
                                             #       The recommended alias Modelfile SYSTEM line omits <|think|>, so thinking is off by default.
       - TIKA_URL=http://tika-server:9998


### PR DESCRIPTION
### Motivation
- Unify the repository's shipped default-model story so the code, compose, and docs consistently target `gemma4:31b` and a pinned Ollama image `ollama/ollama:0.20.4`.
- Preserve the existing runtime default in code (`MODEL_NAME`), and keep the optional local alias `ephemeral-default` available as an advanced/operator choice rather than the shipped default.
- Make only minimal, evidence-based edits to compose and documentation to remove stale references to Qwen and `0.20.2` without unrelated refactors.

### Description
- Updated `docker-compose.yml` to set the shipped app environment to `LLM_MODEL_NAME=gemma4:31b` and confirmed the Ollama image is pinned to `ollama/ollama:0.20.4` while keeping a concise customization comment (`docker-compose.yml`).
- Updated `README.md` to replace stale Qwen language with Gemma 4, change model tag references to `gemma4:31b`, and update the pinned Ollama reference to `0.20.4` (`README.md`).
- Updated `System Deployment Guide.md` to remove the first-run `sed` rewrite that switched `ephemeral-default` to `gemma4:31b`, state that `docker-compose.yml` already ships with `LLM_MODEL_NAME=gemma4:31b`, and mark the local alias flow as optional/advanced (`System Deployment Guide.md`).
- Left `ephemeral_app.py` runtime behavior unchanged and verified the code default remains `MODEL_NAME = os.getenv("LLM_MODEL_NAME", "gemma4:31b")` (`ephemeral_app.py`); `AGENTS.md` already reflected `gemma4:31b` so it was not modified.
- Files changed: `docker-compose.yml`, `README.md`, and `System Deployment Guide.md`.
- Remaining `ephemeral-default` references are intentional and limited to optional/local-alias guidance in `README.md` and `System Deployment Guide.md` and a generic compose comment, and are not used as the shipped default.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it succeeded: `py_compile: OK`.
- Grep validation for the three target terms across the key files found `gemma4:31b` in `ephemeral_app.py`, `docker-compose.yml`, `README.md`, `System Deployment Guide.md`, and `AGENTS.md`, confirming the default is consistently documented and shipped.
- Grep validation found `ephemeral-default` only in optional alias/customization guidance in `README.md`, `System Deployment Guide.md`, and a compose comment, confirming it is not the shipped default.
- Grep validation found `0.20.4` in `docker-compose.yml`, `README.md`, and `System Deployment Guide.md`, and no `0.20.2` or `Qwen/qwen` matches remained in the targeted files, confirming pinned Ollama version and stale Qwen text were updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0520fab9483289b043aa3fda1d749)