### PR TITLE
docs: align thinking-mode guidance with shipped runtime behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
 - `System Deployment Guide.md` — End-user deployment instructions (target audience: IT
   generalists, not developers). Written for WSL2 + Docker on Windows 11.
 - `README.md` — Project overview, feature list, system requirements.
-- `system_prompt_template.md` — LLM system prompt template. Includes Gemma 4
-  thinking control guidance via the `<|think|>` token in the system prompt.
+- `system_prompt_template.md` — LLM system prompt template. The default template is
+  model-agnostic and omits `<|think|>`.
 - `.streamlit/config.toml` — Streamlit theme and config. The Dockerfile merges server
   settings into this file at build time.
 - `theme.css` — Custom CSS loaded by the app.
@@ -41,8 +41,8 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
   Ollama's `/api/show` endpoint, so it adapts to different models automatically.
 - Gemma 4 models may emit thought-channel blocks during streaming in the
   `<|channel>thought\n...<channel|>` format. The app includes a streaming filter
-  that strips these, and thinking is controlled by the `<|think|>` token in the
-  system prompt.
+  that strips these. The shipped app also sends `reasoning_effort="none"` on chat
+  requests, so extended reasoning is effectively disabled by default.
 
 ## Testing
 - Verify Python syntax: `python -m py_compile ephemeral_app.py`
@@ -60,6 +60,6 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
 - Do not modify `system_prompt_template.md` unless changing the LLM's system behavior.
 - Do not add new Python dependencies beyond what's in `requirements.txt` without
   documenting the reason.
-- Do not remove Gemma 4 thinking guidance from `system_prompt_template.md` or the
-  thought-channel streaming filter from `ephemeral_app.py`. Both are required for
-  correct Gemma 4 model output (including `<|channel>thought\n...<channel|>` blocks).
+- Do not remove the thought-channel streaming filter from `ephemeral_app.py`; it is
+  required to suppress Gemma 4 thought-channel output (`<|channel>thought\n...<channel|>`
+  blocks) from displayed responses.

--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -233,7 +233,7 @@ This will take a while depending on your internet speed. When it completes, you 
 
 **A note on context window size:** Ollama automatically scales the context window based on your available VRAM (4k tokens under 24 GB, 32k from 24–48 GB, 256k at 48+ GB). This auto-scaling is a good default for most users. If you want to pin a specific context size for more predictable VRAM usage, see the "Stable Local Alias" section below.
 
-**A note on thinking mode:** Gemma 4 supports an extended reasoning mode activated by including a `<|think|>` token in the system prompt. EphemerAl's default system prompt does not include this token, which tells the model not to use extended reasoning. However, Gemma 4 may still occasionally emit empty or minimal thought output even when thinking is not requested; the app's streaming logic filters this from the displayed response automatically. If you want to experiment with thinking mode, see the alias section below for how to enable it.
+**A note on thinking mode:** In the shipped app, extended reasoning is effectively disabled by default. The default `system_prompt_template.md` is model-agnostic and omits `<|think|>`, and chat requests also set `reasoning_effort="none"`. Gemma 4 may still occasionally emit thought-channel output, but the app's streaming logic filters that from displayed responses. If you want to experiment with thinking mode, plan on app/runtime changes in addition to any prompt or Modelfile edits.
 
 
 ## Step 5: Verify the Installation
@@ -324,7 +324,7 @@ If the page works locally but not from another device, confirm your Windows netw
 
 ## Optional (Advanced/Operator): Stable Local Alias
 
-For operators who want more control over model parameters, you can create a local alias that pins specific settings. This is optional and not required for normal deployments. It is useful if you want to lock the context window to a predictable size, enable or disable thinking mode explicitly, or insulate the app from upstream changes to the Ollama model tag.
+For operators who want more control over model parameters, you can create a local alias that pins specific settings. This is optional and not required for normal deployments. It is useful if you want to lock the context window to a predictable size or insulate the app from upstream changes to the Ollama model tag.
 
 Enter the Ollama container:
 
@@ -360,4 +360,4 @@ Some notes on the parameters in this Modelfile:
 
 - **num_ctx 4000** pins the context window to 4,000 tokens regardless of your VRAM. This is a conservative choice for predictable memory usage. Ollama's default auto-scaling would give you 32k on a 24–48 GB card, or 256k at 48+ GB. If you have VRAM headroom and want longer conversations or larger document uploads, increase this value or remove the line to let Ollama auto-scale.
 - **num_gpu 99** tells Ollama to offload as many layers as possible to the GPU.
-- **SYSTEM line** omits the `<|think|>` token, which tells Gemma 4 not to use extended reasoning. To enable thinking mode, change the line to: `SYSTEM "<|think|>\nYou are a helpful assistant."`. Be aware that thinking mode increases response time and VRAM usage, and the app's streaming filter will strip thought blocks from the displayed output.
+- **SYSTEM line** is intentionally simple and model-agnostic. In the shipped app, changing this line alone does not enable visible thinking mode because chat requests also force `reasoning_effort="none"`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,8 @@ services:
     environment:
       - LLM_BASE_URL=http://ollama:11434/v1
       - LLM_MODEL_NAME=gemma4:31b          # CUSTOMIZE: Change to any Ollama tag or local alias if needed.
-                                            # NOTE: Gemma 4 does not use /no_think. Thinking is controlled by the <|think|> token in the system prompt.
-                                            #       The recommended alias Modelfile SYSTEM line omits <|think|>, so thinking is off by default.
+                                            # NOTE: The default prompt template omits <|think|>, and the app sends
+                                            #       reasoning_effort=none on chat requests, so extended reasoning is off by default.
       - TIKA_URL=http://tika-server:9998
       - TIKA_CLIENT_ONLY=true
       - STREAMLIT_SERVER_HEADLESS=true

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -180,9 +180,9 @@ def timestamp_local() -> str:
 
 tmpl_path = pathlib.Path(__file__).parent / "system_prompt_template.md"
 if tmpl_path.exists():
-    # Gemma 4 thinking is controlled by the <|think|> token in the system prompt.
-    # Our template omits that token, so thinking is off by default; the streaming
-    # think-block filter remains as defense-in-depth.
+    # Default system template is model-agnostic and omits <|think|>.
+    # The request path also sends reasoning_effort="none", so extended reasoning
+    # is effectively disabled by default; keep the think-block filter as defense-in-depth.
     SYSTEM_TMPL = string.Template(tmpl_path.read_text(encoding="utf-8"))
 else:
     SYSTEM_TMPL = string.Template(
@@ -1213,8 +1213,9 @@ if prompt_in is not None:
         with st.spinner("Thinking…"):
             try:
                 client = get_llm_client()
-                # Ollama's Gemma 4 chat template enables thinking by default, regardless
-                # of system prompt content, so reasoning_effort must be forced to "none".
+                # Keep reasoning_effort set to "none" for shipped behavior. Combined with
+                # the default system template omitting <|think|>, this keeps extended
+                # reasoning effectively disabled by default.
 
                 # Try include_usage if supported, fall back otherwise.
                 try:


### PR DESCRIPTION
### Motivation
- Fix inconsistent documentation that implied adding `<|think|>` to prompts or Modelfiles alone enables Gemma 4 "thinking" in the shipped app. 
- Make comments and guides truthful about the shipped runtime: the default system template is model-agnostic and omits `<|think|>`, and the app also requests `reasoning_effort="none"` on chat calls. 

### Description
- Update `AGENTS.md` to remove the incorrect claim that `system_prompt_template.md` contains Gemma-specific `<|think|>` guidance and to state the default template is model-agnostic and omits `<|think|>`, and that the shipped app sends `reasoning_effort="none"` on chat requests. 
- Update `docker-compose.yml` comments near `LLM_MODEL_NAME` to state that the default prompt omits `<|think|>` and that the app sets `reasoning_effort=none`, instead of implying `<|think|>` alone controls thinking behavior. 
- Rewrite the thinking-mode note in `System Deployment Guide.md` to explain extended reasoning is effectively disabled by default and to warn that enabling the mode requires app/runtime changes in addition to prompt/Modelfile edits. 
- Adjust inline comments in `ephemeral_app.py` around system prompt loading and the chat request path to reflect that the template omits `<|think|>` and that chat requests include `reasoning_effort="none"`, while leaving runtime behavior unchanged. 
- Leave `system_prompt_template.md` content unchanged (model-agnostic, no `<|think|>` added). 
- Explicit confirmation: the docs no longer claim `system_prompt_template.md` already contains `<|think|>`. 

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it succeeded. 
- Searched the target files for occurrences of `<|think|>`, `reasoning_effort`, and `thinking` and confirmed the updated references appear only in comments/docs and the runtime still sends `reasoning_effort="none"`; validation output follows:
```
py_compile: OK
===== ephemeral_app.py =====
183:    # Default system template is model-agnostic and omits <|think|>.
184:    # The request path also sends reasoning_effort="none", so extended reasoning
1216:                # Keep reasoning_effort set to "none" for shipped behavior. Combined with
1217:                # the default system template omitting <|think|>, this keeps extended
1227:                        extra_body={"reasoning_effort": "none"},
1234:                        extra_body={"reasoning_effort": "none"},
1242:                            extra_body={"reasoning_effort": "none"},

===== AGENTS.md =====
26:  model-agnostic and omits `<|think|>`.
44:  that strips these. The shipped app also sends `reasoning_effort="none"` on chat

===== docker-compose.yml =====
97:                                            # NOTE: The default prompt template omits <|think|>, and the app sends
98:                                            #       reasoning_effort=none on chat requests, so extended reasoning is off by default.

===== System Deployment Guide.md =====
236:**A note on thinking mode:** In the shipped app, extended reasoning is effectively disabled by default. The default `system_prompt_template.md` is model-agnostic and omits `<|think|>`, and chat requests also set `reasoning_effort="none"`. Gemma 4 may still occasionally emit thought-channel output, but the app's streaming logic filters that from displayed responses. If you want to experiment with thinking mode, plan on app/runtime changes in addition to any prompt or Modelfile edits.
363:- **SYSTEM line** is intentionally simple and model-agnostic. In the shipped app, changing this line alone does not enable visible thinking mode because chat requests also force `reasoning_effort="none"`.

===== system_prompt_template.md =====
(unchanged)
```
- All automated checks passed. No runtime behavior was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e114b1efb88328ad2cf8dd2fbffdb2)