### PR TITLE
Update compose runtime pins to Ollama 0.21.0 and Tika 3.3.0.0-full

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ EphemerAl is designed for trusted local networks (home, office LAN) and does not
 - Ollama API (OpenAI-compatible endpoint for chat)
 - Apache Tika server
 - Docker Compose (for the included deployment path)
-- Pinned Ollama container image in compose: `ollama/ollama:0.20.4`
+- Pinned Ollama container image in compose: `ollama/ollama:0.21.0`
+- Pinned Apache Tika container image in compose: `apache/tika:3.3.0.0-full`
 
 ## Hardware Planning (honest baseline)
 

--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -210,6 +210,8 @@ cd ~/ephemeral-llm
 
 The `docker-compose.yml` file already ships with `LLM_MODEL_NAME=gemma4:31b`, so no model-name change is needed for a standard first run.
 
+If you are upgrading an existing install that already uses the `ephemeral-default` alias, you can keep that alias workflow. In that case, leave your alias in place and set `LLM_MODEL_NAME=ephemeral-default` instead of switching back to the raw upstream tag.
+
 Now start the stack:
 
 ```bash
@@ -218,7 +220,7 @@ docker compose up -d --build
 
 The first run takes several minutes because Docker needs to download container images and build the app. When it finishes, all three containers will be running in the background.
 
-The compose file pins Ollama to version `0.20.4` for tested compatibility with Gemma 4 (including flash attention and Q8 KV cache). Check the Ollama releases page before changing this version.
+The compose file pins Ollama to version `0.21.0` and Apache Tika to `3.3.0.0-full` for tested compatibility with Gemma 4 (including flash attention and Q8 KV cache). Check each project's release notes before changing these versions.
 
 
 ## Step 4: Download the AI Model
@@ -252,7 +254,7 @@ docker compose ps
 docker exec -it ollama ollama list
 ```
 
-You should see all three containers in a "running" state, and `gemma4:31b` listed in the Ollama model list.
+You should see all three containers in a "running" state, and either `gemma4:31b` or `ephemeral-default` listed in the Ollama model list (depending on whether you kept the direct model tag or adopted the alias workflow).
 
 If a container is not running, check its logs for errors:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     # Pinned for compatibility with gemma4 tags. Last validated: April 2026.
     # Check https://github.com/ollama/ollama/releases before upgrading.
     # NOTE: ollama/ollama#14716 (vision+thinking) is fixed; workaround retained as defense-in-depth.
-    image: ollama/ollama:0.20.4
+    image: ollama/ollama:0.21.0
     container_name: ollama
     restart: unless-stopped
     networks: [llm-net]
@@ -62,7 +62,7 @@ services:
   # Apache Tika — document parsing
   # --------------------------------------------------------------------------
   tika-server:
-    image: apache/tika:3.2.3.0-full
+    image: apache/tika:3.3.0.0-full
     container_name: tika-server
     restart: unless-stopped
     networks: [llm-net]


### PR DESCRIPTION
### Motivation
- Bring the runtime stack image pins up to the tested versions for compatibility and maintenance while making the smallest safe change possible. 
- Keep the three-service Docker Compose layout and all privacy/performance settings intact while updating only the Ollama and Tika runtime images.

### Description
- Updated `docker-compose.yml` image pins: `ollama/ollama:0.20.4` → `ollama/ollama:0.21.0` and `apache/tika:3.2.3.0-full` → `apache/tika:3.3.0.0-full`.
- Updated documentation references in `README.md` and `System Deployment Guide.md` to reflect the new pinned versions and to add guidance for upgrades that preserve an existing `ephemeral-default` alias.
- Preserved all existing Ollama environment variables (including `OLLAMA_HOST`, `OLLAMA_ORIGINS`, `OLLAMA_MAX_LOADED_MODELS`, `OLLAMA_FORCE_CUBLAS_LT`, `OLLAMA_KEEP_ALIVE`, `OLLAMA_FLASH_ATTENTION`, and `OLLAMA_KV_CACHE_TYPE`), GPU reservation, volumes, expose/ports, `tmpfs`, logging, container names, networks, and the default first-run `LLM_MODEL_NAME=gemma4:31b` behavior.
- Made no changes to application code or dependency files and retained privacy/performance comments and alias guidance.

### Testing
- Ran a repository search with `rg -n "0\.20\.4|3\.2\.3\.0"` and confirmed no remaining stale references requiring changes.
- Verified protected files remained unchanged with `git diff -- requirements.txt theme.css Dockerfile ephemeral_app.py system_prompt_template.md` (no diffs present). 
- Confirmed only the intended files (`docker-compose.yml`, `README.md`, `System Deployment Guide.md`) were modified via `git status --short` before finalizing the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2718c2104832882e5ee484191f841)