### PR TITLE
Update Compose for Qwen3.6 defaults and add optional Ollama API override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Optional operator overrides (copy to .env and adjust as needed)
+OLLAMA_API_BIND=127.0.0.1
+OLLAMA_MAX_QUEUE=16
+LLM_OUTPUT_RESERVE_TOKENS=32768

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -1,0 +1,15 @@
+###############################################################################
+# docker-compose.api.yml — optional Ollama API exposure override
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.api.yml up -d
+#
+# Security warning:
+#   Raw Ollama in this stack has no application-layer authentication.
+#   Do not expose it broadly without firewall, VPN, and/or reverse-proxy controls.
+###############################################################################
+
+services:
+  ollama:
+    ports:
+      - "${OLLAMA_API_BIND:-127.0.0.1}:11434:11434"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 #   • ephemeral-app — Streamlit front-end website
 #
 # CUSTOMIZE comments below flag the lines that most people tweak:
-#   • LLM model name tag (for example gemma4:31b or ephemeral-default)
+#   • LLM model name tag (for example qwen3.6:35b-a3b or ephemeral-default)
 #   • Service / container names if you prefer different labels
 ###############################################################################
 
@@ -16,7 +16,7 @@ services:
   # Large-language-model back-end (Ollama)
   # --------------------------------------------------------------------------
   ollama:
-    # Pinned for compatibility with gemma4 tags. Last validated: April 2026.
+    # Pinned for compatibility with Qwen3.6-35B-A3B / ephemeral-default. Last validated: April 2026.
     # Check https://github.com/ollama/ollama/releases before upgrading.
     # NOTE: ollama/ollama#14716 (vision+thinking) is fixed; workaround retained as defense-in-depth.
     image: ollama/ollama:0.21.0
@@ -31,14 +31,16 @@ services:
     environment:
       # NVIDIA_VISIBLE_DEVICES=all lets the container see every GPU the host has.
       - NVIDIA_VISIBLE_DEVICES=all
-      - OLLAMA_HOST=0.0.0.0
-      - OLLAMA_ORIGINS=*
+      - OLLAMA_HOST=0.0.0.0:11434
+      - OLLAMA_ORIGINS=${OLLAMA_ORIGINS:-}
       - OLLAMA_MAX_LOADED_MODELS=1
-      # Helpful for dense-model GEMM performance (including Gemma 4 31B).
+      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_MAX_QUEUE=${OLLAMA_MAX_QUEUE:-16}
+      # Helpful CUDA GEMM path for supported GPU workloads.
       - OLLAMA_FORCE_CUBLAS_LT=1
       - OLLAMA_KEEP_ALIVE=-1
       - OLLAMA_FLASH_ATTENTION=1
-      - OLLAMA_KV_CACHE_TYPE=q8_0          # Q8 KV cache: ~50% VRAM savings vs f16 default; requires FLASH_ATTENTION=1 above.
+      - OLLAMA_KV_CACHE_TYPE=q8_0          # Q8 KV cache precision (KV memory only, not model-weight quantization); requires FLASH_ATTENTION=1 above.
 
     # Intentionally internal-only on llm-net for privacy; temporarily switch to
     # ports: ["11434:11434"] for local host debugging with curl if needed.
@@ -93,9 +95,16 @@ services:
 
     environment:
       - LLM_BASE_URL=http://ollama:11434/v1
-      - LLM_MODEL_NAME=gemma4:31b          # CUSTOMIZE: Change to any Ollama tag or local alias if needed.
-                                            # NOTE: The default prompt template omits <|think|>, and the app sends
-                                            #       reasoning_effort=none on chat requests, so extended reasoning is off by default.
+      - LLM_MODEL_NAME=ephemeral-default   # Default alias for Qwen3.6-35B-A3B in this stack.
+      - LLM_CONTEXT_TOKENS=262144          # App-side budgeting hint for document/context packing.
+      # Actual Ollama context window is set by PARAMETER num_ctx in the ephemeral-default Modelfile.
+      - LLM_OUTPUT_RESERVE_TOKENS=${LLM_OUTPUT_RESERVE_TOKENS:-32768}
+      - LLM_REASONING_EFFORT=none
+      - LLM_SHOW_REASONING=false
+      - LLM_TEMPERATURE=0.7
+      - LLM_TOP_P=0.8
+      - LLM_PRESENCE_PENALTY=1.5
+      - LLM_MAX_TOKENS=                    # Blank means EphemerAl does not impose an output cap.
       - TIKA_URL=http://tika-server:9998
       - TIKA_CLIENT_ONLY=true
       - STREAMLIT_SERVER_HEADLESS=true


### PR DESCRIPTION
### Motivation
- Move the compose defaults and documentation from Gemma-focused wording to the Qwen3.6 / `ephemeral-default` model alias and provide safer, operator-configurable Ollama defaults. 
- Keep Ollama internal by default to preserve the privacy posture while offering an opt-in override for controlled API exposure. 
- Surface application-side context budgeting and sampling defaults so EphemerAl runs non-thinking Qwen3.6-compatible requests by default.

### Description
- Updated `docker-compose.yml` comments and defaults to reference `qwen3.6:35b-a3b` / `ephemeral-default` and kept `image: ollama/ollama:0.21.0`.
- Hardened the `ollama` service environment by setting `OLLAMA_HOST=0.0.0.0:11434`, replacing wildcard origins with a configurable default `OLLAMA_ORIGINS=${OLLAMA_ORIGINS:-}`, adding `OLLAMA_NUM_PARALLEL=1`, `OLLAMA_MAX_QUEUE=${OLLAMA_MAX_QUEUE:-16}`, and clarifying `OLLAMA_KV_CACHE_TYPE=q8_0` as a KV-cache precision setting (not model-weight quantization); retained `OLLAMA_MAX_LOADED_MODELS=1`, `OLLAMA_FORCE_CUBLAS_LT=1`, `OLLAMA_KEEP_ALIVE=-1`, and `OLLAMA_FLASH_ATTENTION=1`.
- Preserved internal-only exposure for Ollama in the default compose (`expose: ["11434"]`) and preserved `llm-net`, `tmpfs` usage, and privacy logging settings.
- Updated `ephemeral-app` environment defaults to `LLM_MODEL_NAME=ephemeral-default`, added `LLM_CONTEXT_TOKENS=262144`, `LLM_OUTPUT_RESERVE_TOKENS=${LLM_OUTPUT_RESERVE_TOKENS:-32768}`, `LLM_REASONING_EFFORT=none`, `LLM_SHOW_REASONING=false`, sampling defaults (`LLM_TEMPERATURE=0.7`, `LLM_TOP_P=0.8`), `LLM_PRESENCE_PENALTY=1.5`, and left `LLM_MAX_TOKENS=` blank with comments clarifying app budgeting vs Ollama `num_ctx` and that blank means no app-imposed output cap.
- Added `docker-compose.api.yml` as an opt-in override which publishes only Ollama using a bind variable defaulting to loopback (`ports: ["${OLLAMA_API_BIND:-127.0.0.1}:11434:11434"]`) and includes a warning that raw Ollama has no application-layer auth.
- Added a minimal `.env.example` with operator knobs: `OLLAMA_API_BIND`, `OLLAMA_MAX_QUEUE`, and `LLM_OUTPUT_RESERVE_TOKENS`.

### Testing
- Ran `docker compose config` in this environment and it failed with `docker: command not found` so the compose file could not be validated here.
- Ran `docker compose -f docker-compose.yml -f docker-compose.api.yml config` in this environment and it also failed with `docker: command not found` so the combined override could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaae61877c8328a88933cf4a29ec40)