### PR TITLE
Update README for Qwen3.6 default alias and optional shared Ollama API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EphemerAl: A Simple Self-Hosted Chat Interface for Local AI with Ollama that Accepts Documents and Images
 
-EphemerAl is a lightweight, open-source web interface for interacting with local LLMs on your hardware via Ollama. I designed it for my day job to help keep our team's sensitive info off cloud services, and to provide a modern AI experience to staff without the per-user cost required to achieve equivalent capabilities online. The repository now defaults to Gemma 4 31B, but can be retargeted to any Ollama model by changing one environment variable (`LLM_MODEL_NAME`).
+EphemerAl is a lightweight, open-source web interface for interacting with local LLMs on your hardware via Ollama. I designed it for my day job to help keep our team's sensitive info off cloud services, and to provide a modern AI experience to staff without the per-user cost required to achieve equivalent capabilities online. The repository now targets Qwen3.6-35B-A3B through a stable local alias (`ephemeral-default`) that you create from `qwen3.6:35b-a3b`, and can still be retargeted to other models by changing one environment variable (`LLM_MODEL_NAME`).
 
 While it wasn't built for broad distribution, I'm sharing this generalized version in case it helps others looking for a local-only, account-free, multimodal LLM interface. . . whether to provide an operational tool, a staff learning environment, or bragging rights when friends visit on your home network.
 
@@ -23,8 +23,19 @@ While it wasn't built for broad distribution, I'm sharing this generalized versi
 
 ### Default target
 
-- **Model:** Gemma 4 31B
-- **Ollama tag:** `gemma4:31b`
+- **Model:** Qwen3.6-35B-A3B
+- **Ollama backing tag:** `qwen3.6:35b-a3b`
+- **App model name:** `ephemeral-default`
+
+Using a stable local alias is intentional: it lets you pin runtime defaults (like context and generation parameters) in one place while the app consistently calls `ephemeral-default`.
+
+### Runtime assumptions in this repo
+
+- **256K target context:** set through alias Modelfile `num_ctx 262144`.
+- **q8 KV cache target:** configured via Ollama environment variable in the deployment path.
+- **Non-thinking by default:** requests use `reasoning_effort="none"`.
+- **No default EphemerAl output cap:** the app does not set `max_tokens` unless you explicitly configure `LLM_MAX_TOKENS`.
+- **Document budgeting reserve:** `LLM_OUTPUT_RESERVE_TOKENS` keeps response headroom while loading documents into context; it is not an output cap.
 
 ### Retarget to a different model
 
@@ -46,6 +57,8 @@ EphemerAl is designed to minimize data retention:
 
 Note that browser caching behavior depends on your browser settings and cache-control headers. For maximum privacy on shared machines, use private/incognito browsing or clear browser data after use.
 
+If you enable a shared Ollama API backend, requests made directly to Ollama bypass the EphemerAl UI/session layer; privacy and logging behavior for those requests depends on the external client and Ollama deployment settings, not EphemerAl session behavior.
+
 ## Network Security Note
 
 EphemerAl is designed for trusted local networks (home, office LAN) and does not implement authentication or transport encryption. The Streamlit container disables CORS and XSRF protection to allow straightforward LAN access. Do not expose this application to the public internet without adding a reverse proxy with authentication and TLS.
@@ -61,20 +74,20 @@ EphemerAl is designed for trusted local networks (home, office LAN) and does not
 
 ## Hardware Planning (honest baseline)
 
-Gemma 4 31B is substantially heavier than small local models.
+Qwen3.6-35B-A3B is a large model and should be planned like one.
 
-- **Recommended:** 32 GB+ total VRAM.
-- **Works for many users:** 24 GB total VRAM (usually with lower context).
+- **Target baseline:** 32 GB total VRAM for this deployment (including multi-GPU setups such as 2x 16 GB cards).
+- **Operator validation required:** verify actual context realization and GPU residency with `ollama ps` after deployment.
 - **CPU-only fallback:** technically possible in some setups but usually too slow for interactive use.
 
-If this model is too heavy for your machine, use a smaller Ollama model tag in `LLM_MODEL_NAME`.
+If this model is too heavy for your machine, retarget `LLM_MODEL_NAME` to a smaller local model.
 
 ## System Requirements
 
 To run this interface effectively, the following specifications are recommended.
 
 - **Operating System:** Windows 11 Pro or Enterprise, fully updated. WSL will be installed as part of setup (if not already present).
-- **Graphics Processing Unit:** One or more discrete NVIDIA GPU(s), preferably from the 30-series or later. Gemma 4 31B benefits from 24GB+ VRAM; 32GB+ recommended for full context.
+- **Graphics Processing Unit:** One or more discrete NVIDIA GPU(s), preferably from the 30-series or later. Plan for 32 GB total VRAM for Qwen3.6-35B-A3B (including multi-GPU combinations such as 2x 16 GB).
 - **Nvidia Driver:** The most recent WHQL-certified NVIDIA GPU driver. Optional components may be omitted.
 - **Additional Note:** If available, connect display to integrated graphics to allocate more VRAM to the NVIDIA GPU(s).
 
@@ -84,12 +97,21 @@ Use the step-by-step guide:
 
 - [System Deployment Guide](System%20Deployment%20Guide.md)
 
-### Migrating an existing Gemma-based install
+### Migration note for existing Gemma-based installs
 
-If your current stack still points at an older Gemma tag (for example `gemma3-prod`), use the migration section in the deployment guide to move forward to Gemma 4 by switching to either:
+If your current stack still points at an older Gemma tag, recreate or update your local `ephemeral-default` alias to point to `qwen3.6:35b-a3b` using the deployment guide, then confirm `docker-compose.yml` uses `LLM_MODEL_NAME=ephemeral-default`.
 
-- `LLM_MODEL_NAME=gemma4:31b` directly, or
-- a neutral local alias like `ephemeral-default` that maps to `gemma4:31b`.
+## Shared Ollama API Backend (optional)
+
+- Raw Ollama remains internal by default in this stack.
+- If you intentionally want shared API access, use the `docker-compose.api.yml` override to expose port `11434`.
+- External OpenAI-compatible clients should use:
+  - `model: "ephemeral-default"`
+  - `reasoning_effort: "none"`
+  - `temperature: 0.7`
+  - `top_p: 0.8`
+  - `presence_penalty: 1.5`
+- Important: raw Ollama exposure in this stack does not add app-level authentication by itself.
 
 ## Accessing EphemerAl
 


### PR DESCRIPTION
### Motivation

- Replace the previous Gemma-focused README text with accurate, high-level documentation for the new Qwen3.6-35B-A3B target and the alias-based workflow. 
- Surface the key model/runtime assumptions (context size, KV cache, non-thinking defaults, and document budgeting) so readers understand deployment expectations without duplicating the full deployment guide. 
- Add concise guidance for an optional shared Ollama API backend and clarify privacy implications when callers bypass the EphemerAl UI. 

### Description

- Update the README opening paragraph to state the repository now targets `Qwen3.6-35B-A3B` via a stable local alias `ephemeral-default` created from `qwen3.6:35b-a3b`. 
- Replace the Default Model section to document `Model: Qwen3.6-35B-A3B`, `Ollama backing tag: qwen3.6:35b-a3b`, and `App model name: ephemeral-default`, and add a short note on why alias pinning is intentional. 
- Add a concise "Runtime assumptions" subsection describing `num_ctx 262144` (256K), q8 KV cache, `reasoning_effort="none"` default, that the app does not set `max_tokens` unless `LLM_MAX_TOKENS` is configured, and `LLM_OUTPUT_RESERVE_TOKENS` behavior. 
- Update hardware guidance to recommend a 32 GB total VRAM baseline (including multi-GPU like 2x 16 GB), instruct operators to verify runtime/GPU residency with `ollama ps`, replace the Gemma migration section with a short migration note to recreate/update `ephemeral-default`, and add a short "Shared Ollama API Backend (optional)" section with caller parameter recommendations and an authentication warning. 

### Testing

- Confirmed file changes and presence with `rg --files | rg 'AGENTS.md|README.md|System Deployment Guide.md|docker-compose.yml'` which included the expected files. 
- Inspected the edited README snippet with `sed -n '1,260p' README.md` and validated substitutions for Gemma references via `rg -n 'Gemma|gemma4|gemma3' README.md`. 
- Cross-checked consistency with deployment docs using `rg -n` for keys (`qwen3.6`, `ephemeral-default`, `num_ctx`, `LLM_OUTPUT_RESERVE_TOKENS`, `ollama ps`) against `System Deployment Guide.md` and `docker-compose.yml`. 
- Validated relative links in the README with a small Python check and committed the change with `git commit`, and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab1a01a388328bb9ab6bf50316029)