### PR TITLE
docs: final consistency cleanup for Qwen3.6 defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Use the step-by-step guide:
 
 - [System Deployment Guide](System%20Deployment%20Guide.md)
 
-### Migration note for existing Gemma-based installs
+### Migration note for pre-Qwen installs
 
-If your current stack still points at an older Gemma tag, recreate or update your local `ephemeral-default` alias to point to `qwen3.6:35b-a3b` using the deployment guide, then confirm `docker-compose.yml` uses `LLM_MODEL_NAME=ephemeral-default`.
+If your current stack still points at any older model tag, recreate or update your local `ephemeral-default` alias to point to `qwen3.6:35b-a3b` using the deployment guide, then confirm `docker-compose.yml` uses `LLM_MODEL_NAME=ephemeral-default`.
 
 ## Shared Ollama API Backend (optional)
 


### PR DESCRIPTION
### Motivation
- Remove a stale Gemma-specific migration wording and ensure repo guidance and defaults consistently reflect the Qwen3.6 / `ephemeral-default` migration while making only minimal, targeted edits.

### Description
- Replaced the README heading and migration note that referenced "Gemma" with a model-agnostic "pre-Qwen" wording to avoid misleading operators. 
- Performed a repo-wide scan for legacy/Qwen-related terms and confirmed no other stale references required changes. 
- No runtime code or architecture changes were made; this is a docs-only, small consistency cleanup.

### Testing
- Verified Python syntax by running `python -m py_compile ephemeral_app.py`, which succeeded. 
- Inspected `docker-compose.yml`, `docker-compose.api.yml`, `ephemeral_app.py`, `System Deployment Guide.md`, `AGENTS.md`, and `README.md` to confirm the following defaults and behaviors: `LLM_MODEL_NAME=ephemeral-default`, `LLM_CONTEXT_TOKENS=262144`, `LLM_REASONING_EFFORT=none`, `LLM_TEMPERATURE=0.7`, `LLM_TOP_P=0.8`, `LLM_PRESENCE_PENALTY=1.5`, blank `LLM_MAX_TOKENS`, Ollama internal by default, request-level `presence_penalty` and `reasoning_effort` defaults, `max_tokens` only sent when `LLM_MAX_TOKENS` is set, reasoning deltas discarded unless `LLM_SHOW_REASONING=true`, and Modelfile examples omit `presence_penalty`; all checks matched expectations. 
- Attempted to run `docker compose config` and `docker compose -f docker-compose.yml -f docker-compose.api.yml config` but those commands could not be executed in this environment because `docker` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab2e188788328a760f02969b581bf)