### PR TITLE
Discard trailing stream buffer when stream ends inside an unclosed think block

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1392,8 +1392,10 @@ if prompt_in is not None:
                 if stream_parse_buffer:
                     if not in_think_block:
                         acc += stream_parse_buffer
-                    elif not acc.strip():
-                        acc += stream_parse_buffer
+                    elif DEBUG_MODE:
+                        logging.debug(
+                            "Discarding trailing stream buffer because stream ended inside a think block."
+                        )
 
                 acc = re.sub(r"<\|channel>thought\n.*?<channel\|>\s*", "", acc, flags=re.DOTALL)
                 acc = re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)


### PR DESCRIPTION
### Motivation
- Prevent leaking hidden reasoning by ensuring any trailing `stream_parse_buffer` is appended only when `in_think_block` is `False`, removing the unsafe fallback that could append buffered content when a think block was opened but never closed.

### Description
- In `ephemeral_app.py` replaced the `elif not acc.strip(): acc += stream_parse_buffer` fallback with a `DEBUG_MODE`-only `logging.debug` message so trailing buffered content is discarded if the stream ends while `in_think_block` is `True` and is still appended when `in_think_block` is `False`.

### Testing
- Ran `python -m py_compile ephemeral_app.py` which passed, and there were no repository automated tests to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab86dd40483289543f2b50f646864)