### PR TITLE
Avoid persisting generated image base64 in session message parts

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1257,7 +1257,6 @@ if prompt_in is not None:
                         img_b64 = part.get("b64")
                         if not img_b64:
                             img_b64 = base64.b64encode(img_bytes).decode()
-                            part["b64"] = img_b64  # cache per-session
                         mime = part.get("mime_type", "image/jpeg")
                         api_parts.append(
                             {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{img_b64}"}}


### PR DESCRIPTION
### Motivation
- Prevent unnecessary duplication of image data in session memory by avoiding caching newly generated base64 strings into message parts, which adds ~33% overhead and can increase memory pressure in image-heavy sessions.

### Description
- In `ephemeral_app.py` stop writing the generated base64 back into the message part (removed the `part["b64"] = img_b64` assignment) while still transiently encoding image bytes for the API payload and still honoring any pre-existing `b64` values.

### Testing
- Ran `python -m py_compile ephemeral_app.py`, which succeeded. 
- Scanned the repo for tests with `rg` and found no automated tests to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab90204fc832880893ed0ad1037ff)