### PR TITLE
Drop oversized user turn from history on context overflow

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1209,11 +1209,18 @@ if prompt_in is not None:
         }
     )
 
-    # If still too large even after dropping docs, respond as assistant and stop.
+    # If still too large even after dropping docs, remove the just-appended oversized
+    # user turn so it doesn't poison subsequent requests, then respond as assistant and stop.
     if prompt_token_estimate > max_ctx:
+        if st.session_state.messages:
+            last_msg = st.session_state.messages[-1]
+            if last_msg.get("role") == "user" and last_msg.get("id") == user_msg_id:
+                st.session_state.messages.pop()
+
         assistant_msg_id = str(uuid.uuid4())
         error_text = (
-            "That request is too large for this AI model right now. "
+            "That request is too large for this AI model right now, so I omitted that oversized request "
+            "from conversation history to keep this session usable. "
             "Try removing a few attachments, shortening your message, or starting a new conversation."
         )
         with styled_chat_message("assistant", assistant_msg_id):


### PR DESCRIPTION
### Motivation
- Prevent an oversized user submission from remaining in `st.session_state.messages` after the app rejects it for exceeding the model context, which can cause subsequent requests to fail or retain large payloads in memory.

### Description
- In the oversized-request branch (`if prompt_token_estimate > max_ctx`) remove the just-appended user turn when the last message is a `user` message with the same `user_msg_id` so older history is not touched.
- Update the assistant error text so it clearly states the oversized request was omitted from conversation history to keep the session usable.
- The change is confined to that failure path only and leaves token estimation, request flow, and other logic unchanged.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it succeeded.
- Searched the repo for Python tests (`rg` for `test_*.py` / `*_test.py`) and none were found, so no unit tests were executed beyond the syntax check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab990c7fc832895ed520052214702)