### PR TITLE
Remove oversized user turn when backend reports context-length errors

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -1426,8 +1426,13 @@ if prompt_in is not None:
                 lower = msg.lower()
 
                 if "context" in lower and ("length" in lower or "too long" in lower or "maximum" in lower):
+                    if st.session_state.messages:
+                        last_msg = st.session_state.messages[-1]
+                        if last_msg.get("role") == "user" and last_msg.get("id") == user_msg_id:
+                            st.session_state.messages.pop()
                     st.error(
                         "That message is too long for this AI model. "
+                        "I omitted that oversized request from conversation history to keep this session usable. "
                         "Try removing a few attachments, shortening your message, or starting a new conversation."
                     )
                 elif "connection" in lower or "timed out" in lower or "timeout" in lower:


### PR DESCRIPTION
### Motivation
- When the model backend returns a context-length/too-long/maximum error the just-submitted user message remained in `st.session_state.messages` and could poison subsequent requests, so the app should remove only that oversized user turn.

### Description
- In the `except Exception as e:` branch after the model call, add a guarded pop that checks the last message and removes it only if `last_msg.get("role") == "user" and last_msg.get("id") == user_msg_id`, and update the context-error user-facing text to state the oversized request was omitted from conversation history.

### Testing
- Ran `python -m py_compile ephemeral_app.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eabe3963a0832885ca55728913357e)