### PR TITLE
Housekeeping: add ignores, sync Streamlit theme, remove anti-cache tags, trim Dockerfile, document Pillow pin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# VCS metadata
+.git
+.gitignore
+
+# Local environment/secrets
+.env
+.env.*
+*.local
+.streamlit/secrets.toml
+
+# Python caches and virtualenvs
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+env/
+ENV/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.nox/
+.coverage
+.coverage.*
+htmlcov/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+pip-wheel-metadata/
+
+# Editor/OS junk
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# Non-runtime docs and local media artifacts
+AGENTS.md
+README.md
+LICENSE.md
+System Deployment Guide.md
+Ephemeral Screenshot.jpg
+docker-compose.yml
+docker-compose.api.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Packaging and build artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+pip-wheel-metadata/
+
+# Test and tooling caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.pyre/
+.hypothesis/
+.tox/
+.nox/
+.coverage
+.coverage.*
+htmlcov/
+
+# Streamlit local artifacts
+.streamlit/secrets.toml
+
+# Local environment and secrets
+.env
+.env.*
+*.local
+
+# Editor and IDE settings
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,5 +1,5 @@
 [theme]
 base = "light"
-primaryColor = "#007A7A"
-backgroundColor = "#FFFFFF"
-secondaryBackgroundColor = "#E6F2F2"
+primaryColor = "#E1654A"
+backgroundColor = "#FAF6F0"
+secondaryBackgroundColor = "#F3EEE6"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
 - `.streamlit/config.toml` — Streamlit theme and config. The Dockerfile merges server
   settings into this file at build time.
 - `theme.css` — Custom CSS loaded by the app.
+- `.gitignore` — Git hygiene for local/dev artifacts (venvs, caches, editor files, secrets).
+- `.dockerignore` — Docker build-context hygiene to keep non-runtime files out of images; must not exclude `.streamlit/config.toml`.
 - `static/` — Logo and static assets.
 
 ## Conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # --- OS packages --------------------------------------------------
 RUN apt-get update \
- && apt-get install -y build-essential curl \
+ && apt-get install -y curl \
  && rm -rf /var/lib/apt/lists/*
 
 # --- Python deps --------------------------------------------------

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -50,17 +50,6 @@ st.set_page_config(
     initial_sidebar_state="auto",
 )
 
-# ── Anti-caching meta tags ────────────────────────────────────────
-st.markdown(
-    """
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
-    """,
-    unsafe_allow_html=True,
-)
-
-
 def load_css(path: str = "theme.css") -> None:
     """Load optional CSS overrides to customize Streamlit's default look."""
     css_path = pathlib.Path(path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ requests==2.32.5
 pytz==2025.2
 tika==3.1.0
 openai==1.97.2
+# Pinned transitive dependency used by Streamlit image handling; kept for reproducible container builds.
 pillow==11.3.0


### PR DESCRIPTION
### Motivation
- Improve repository hygiene and reduce Docker image/build-context bloat by adding ignore files and keeping non-runtime assets out of builds.
- Make Streamlit's TOML config reflect the `theme.css` source-of-truth so the app's declared theme no longer conflicts with the loaded CSS.
- Remove a browser-ineffective anti-cache HTML injection and document why `pillow==11.3.0` is pinned for reproducible Streamlit image handling.

### Description
- Added `.gitignore` with common Python, virtualenv, cache, editor, OS, test, and local-secret entries and added `.dockerignore` to keep non-runtime docs/media out of the Docker build context while preserving runtime files such as `.streamlit/config.toml`, `theme.css`, `ephemeral_app.py`, `requirements.txt`, `system_prompt_template.md`, and `static/`.
- Synced `.streamlit/config.toml` palette values to match `theme.css` (set `primaryColor = "#E1654A"`, `backgroundColor = "#FAF6F0"`, `secondaryBackgroundColor = "#F3EEE6"`).
- Removed the non-functional anti-cache `st.markdown(...)` block that injected `<meta http-equiv>` tags from `ephemeral_app.py` (the surrounding explanatory comment was also removed), leaving CSS loading and runtime logic unchanged.
- Removed `build-essential` from the `apt-get install` line in `Dockerfile` to reduce image bloat while keeping `curl`, and added a one-line comment above `pillow==11.3.0` in `requirements.txt` explaining the pin.
- Updated `AGENTS.md` Key Files section to mention `.gitignore` and `.dockerignore`, with an explicit warning not to exclude `.streamlit/config.toml` from the Docker context.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it completed successfully.
- Attempted `docker build -t ephemeral-housekeeping-check .` but the execution environment does not provide the `docker` CLI so the image build could not be performed here (please run locally/CI to verify the Docker build and dependency installation without `build-essential`).
- Attempted dependency verification via a temporary venv and `pip install -r requirements.txt` but it failed due to network/proxy restrictions when contacting the package index, so I could not validate package installation without `build-essential` in this environment.
- All changes were committed; no runtime or LLM behavior, environment defaults, or prompt/system templates were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead5e247f48328919edaf68f637938)