### PR TITLE
Extract import-safe utilities, add ThinkStreamFilter and pytest suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,16 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
 
 ## Key Files
 - `ephemeral_app.py` — Main application. All state is in-memory (session_state).
+- `ephemeral/` — Import-safe utility package (no Streamlit side effects at import time).
+- `ephemeral/config.py` — Env parsing helpers and shared configuration constants.
+- `ephemeral/export.py` — Conversation transcript/export builders (Markdown/HTML).
+- `ephemeral/stream_filter.py` — Stateful think-block/thought-channel stream filter.
+- `ephemeral/token_budget.py` — Token estimation helpers.
 - `docker-compose.yml` — Stack definition. Pins Ollama and Tika image versions.
 - `Dockerfile` — Builds the Streamlit app container image.
 - `requirements.txt` — Python dependencies (installed inside the app container).
+- `requirements-dev.txt` — Development-only test dependencies (pytest/coverage).
+- `tests/` — Pytest suite for import-safe utility modules.
 - `System Deployment Guide.md` — End-user deployment instructions (target audience: IT
   generalists, not developers). Written for WSL2 + Docker on Windows 11.
 - `README.md` — Project overview, feature list, system requirements.
@@ -105,10 +112,13 @@ When reviewing Codex changes, treat the following as high-priority checks:
 ## Testing
 - Verify Python syntax: `python -m py_compile ephemeral_app.py`
 - Verify requirements install: `pip install -r requirements.txt && pip check`
+- Verify test tooling + run tests: `pip install -r requirements-dev.txt && python -m pytest`
 - Verify Markdown links resolve: all relative links in README.md and the deployment
   guide should point to files that exist in the repo.
 - Full stack test: `docker compose up -d --build` inside WSL2, then access
   `http://localhost:8501`.
+- Keep `ephemeral/` modules import-safe: no Streamlit imports or Streamlit side effects
+  at import time.
 
 ## Do Not
 - Do not change environment variable defaults in `ephemeral_app.py` to use `localhost`.

--- a/ephemeral/__init__.py
+++ b/ephemeral/__init__.py
@@ -1,0 +1,1 @@
+"""EphemerAl import-safe utility modules."""

--- a/ephemeral/config.py
+++ b/ephemeral/config.py
@@ -1,0 +1,97 @@
+import os
+from typing import Optional
+
+APP_VERSION = "1.8.1"
+
+# Prefix used for synthetic context blocks injected into user messages.
+# We use a flag (_synthetic) to identify these, not string matching.
+CONTEXT_PREFIX = "Context:\n"
+
+# TTL for session-scoped Tika parse cache (seconds)
+TIKA_CACHE_TTL_S = 3600
+
+# Token estimation behavior
+TOKEN_HEURISTIC_CHARS_PER_TOKEN = 3.5
+TOKEN_CACHE_MAX_ENTRIES = 256
+TOKENIZE_TIMEOUT_S = 2.0  # keep UI snappy; budgeting degrades silently if tokenize is slow/unavailable
+
+# Debug mode (shows technical status in sidebar, and error detail expanders)
+DEBUG_MODE = os.getenv("EPHEMERAL_DEBUG", "0").strip().lower() in {"1", "true", "yes", "y", "on"}
+
+# Feature toggle (operator-only)
+ENABLE_TOKEN_BUDGETING = os.getenv("ENABLE_TOKEN_BUDGETING", "1").strip().lower() not in {"0", "false", "no"}
+
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "ephemeral-default")
+TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")
+TIKA_TIMEOUT_S = int(os.getenv("TIKA_TIMEOUT_S", "15"))
+LLM_SUPPORTS_VISION = os.getenv("LLM_SUPPORTS_VISION")
+
+
+def _float_env(name: str, default: float) -> float:
+    """Parse a float env var with safe fallback on missing/blank/invalid values."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except Exception:
+        return default
+
+
+def _int_env_optional(name: str) -> Optional[int]:
+    """Parse an optional int env var; return None for missing/blank/invalid/non-positive values."""
+    raw = os.getenv(name)
+    if raw is None:
+        return None
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+        return value if value > 0 else None
+    except Exception:
+        return None
+
+
+def _int_env(name: str, default: int) -> int:
+    """Parse an int env var with safe fallback on missing/blank/invalid values."""
+    value = _int_env_optional(name)
+    return value if value is not None else default
+
+
+def _bool_env(name: str, default: bool = False) -> bool:
+    """Parse a bool env var with safe fallback on missing/blank/invalid values."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "y", "on"}:
+        return True
+    if value in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+LLM_CONTEXT_TOKENS = _int_env_optional("LLM_CONTEXT_TOKENS")
+LLM_OUTPUT_RESERVE_TOKENS = _int_env("LLM_OUTPUT_RESERVE_TOKENS", 32768)
+LLM_REQUEST_TIMEOUT_S = _float_env("LLM_REQUEST_TIMEOUT_S", 1800.0)
+LLM_MAX_RETRIES = _int_env("LLM_MAX_RETRIES", 0)
+LLM_TEMPERATURE = _float_env("LLM_TEMPERATURE", 0.7)
+LLM_TOP_P = _float_env("LLM_TOP_P", 0.8)
+LLM_PRESENCE_PENALTY = _float_env("LLM_PRESENCE_PENALTY", 1.5)
+LLM_REASONING_EFFORT = os.getenv("LLM_REASONING_EFFORT", "none").strip() or "none"
+LLM_SHOW_REASONING = _bool_env("LLM_SHOW_REASONING", False)
+LLM_MAX_TOKENS = _int_env_optional("LLM_MAX_TOKENS")
+IMG_TOKEN_COST_DEFAULT = _int_env("IMG_TOKEN_COST_DEFAULT", 2048)
+
+
+def _ollama_base_url() -> str:
+    """
+    Convert an OpenAI-style base URL like http://host:11434/v1 into the native Ollama base http://host:11434.
+    If /v1 isn't present, returns the URL without trailing slash.
+    """
+    return LLM_BASE_URL.rstrip("/").split("/v1")[0]

--- a/ephemeral/export.py
+++ b/ephemeral/export.py
@@ -1,0 +1,255 @@
+import re
+from html import escape as html_escape
+from typing import List, Tuple, Union
+
+from ephemeral.config import CONTEXT_PREFIX
+
+
+def build_message_text(messages: List[dict]) -> str:
+    """Flatten message content into text for token estimation."""
+    chunks: List[str] = []
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            for part in content:
+                if part.get("type") == "text":
+                    text = part.get("text")
+                    if text:
+                        chunks.append(text)
+        else:
+            if content:
+                chunks.append(str(content))
+    return "\n".join(chunks)
+
+
+def _extract_export_info(content: Union[str, list]) -> Tuple[List[str], List[str], str]:
+    """
+    Extract (doc_lines, img_lines, message_text) from message content.
+
+    Notes:
+    - We do NOT export the full extracted document text from Context:, only filenames and counts.
+    - Synthetic context parts (marked with _synthetic flag) are parsed for metadata only.
+    """
+    doc_lines: List[str] = []
+    img_lines: List[str] = []
+    text_chunks: List[str] = []
+
+    if not isinstance(content, list):
+        return doc_lines, img_lines, "" if content is None else str(content)
+
+    doc_seen = set()
+    img_seen = set()
+    img_marker_names: List[str] = []
+
+    for part in content:
+        ptype = part.get("type")
+
+        if ptype == "text":
+            text = part.get("text", "")
+
+            if part.get("_synthetic"):
+                ctx = text[len(CONTEXT_PREFIX) :] if text.startswith(CONTEXT_PREFIX) else text
+                blocks = re.split(r"(?m)^---\s*(.+?)\s*---\s*$", ctx)
+                for i in range(1, len(blocks), 2):
+                    fname = (blocks[i] or "").strip()
+                    extracted = blocks[i + 1] if i + 1 < len(blocks) else ""
+                    char_count = len((extracted or "").strip())
+                    if fname and fname not in doc_seen:
+                        doc_seen.add(fname)
+                        doc_lines.append(f"- 📄 {fname} ({char_count:,} characters extracted)")
+
+            elif text.startswith("📄 *") and text.endswith("*"):
+                fname = text[len("📄 *") : -1].strip()
+                if fname and fname not in doc_seen:
+                    doc_seen.add(fname)
+                    doc_lines.append(f"- 📄 {fname}")
+
+            elif text.startswith("📷 *") and text.endswith("*"):
+                fname = text[len("📷 *") : -1].strip()
+                if fname:
+                    img_marker_names.append(fname)
+
+            else:
+                if text and text.strip():
+                    text_chunks.append(text.strip())
+
+        elif ptype == "image":
+            fname = (part.get("filename") or "image").strip()
+            if fname and fname not in img_seen:
+                img_seen.add(fname)
+                img_lines.append(f"- 📷 {fname}")
+
+        elif ptype == "image_url":
+            fname = (part.get("filename") or "image").strip()
+            if fname and fname not in img_seen:
+                img_seen.add(fname)
+                img_lines.append(f"- 📷 {fname}")
+
+    for fname in img_marker_names:
+        if fname not in img_seen:
+            img_seen.add(fname)
+            img_lines.append(f"- 📷 {fname}")
+
+    message_text = "\n\n".join(text_chunks).strip()
+    return doc_lines, img_lines, message_text
+
+
+def build_conversation_markdown(messages: List[dict]) -> str:
+    """Build a Markdown transcript used as plain-text clipboard fallback."""
+    lines: List[str] = ["# EphemerAl Conversation", ""]
+
+    for msg in messages:
+        role = msg.get("role", "assistant")
+        role_title = "User" if role == "user" else "Assistant"
+        lines.append(f"**{role_title}**")
+
+        doc_lines, img_lines, message_text = _extract_export_info(msg.get("content", ""))
+
+        if doc_lines or img_lines:
+            lines.append("")
+            lines.append("Attachments:")
+            lines.extend(doc_lines)
+            lines.extend(img_lines)
+
+        if message_text:
+            lines.append("")
+            lines.append(message_text)
+
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _inline_md_to_html(text: str) -> str:
+    """Minimal inline Markdown -> HTML for clipboard friendliness."""
+    t = html_escape(text)
+    t = re.sub(r"`([^`]+)`", r"<code>\1</code>", t)
+    t = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", t)
+    t = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", t)
+    return t
+
+
+def _md_block_to_html(md_block: str) -> str:
+    """Minimal block Markdown -> HTML for clipboard friendliness."""
+    md_block = (md_block or "").replace("\r\n", "\n")
+    lines = md_block.split("\n")
+
+    out: List[str] = []
+    para: List[str] = []
+    in_ul = False
+    in_ol = False
+
+    def flush_para() -> None:
+        nonlocal para
+        if para:
+            out.append("<p>" + "<br>".join(para) + "</p>")
+            para = []
+
+    def close_lists() -> None:
+        nonlocal in_ul, in_ol
+        if in_ul:
+            out.append("</ul>")
+            in_ul = False
+        if in_ol:
+            out.append("</ol>")
+            in_ol = False
+
+    for raw in lines:
+        stripped = (raw or "").strip()
+
+        if stripped == "":
+            flush_para()
+            continue
+
+        if stripped in {"---", "***", "___"}:
+            flush_para()
+            close_lists()
+            out.append("<hr>")
+            continue
+
+        m = re.match(r"^(#{1,6})\s+(.*)$", stripped)
+        if m:
+            flush_para()
+            close_lists()
+            level = len(m.group(1))
+            out.append(f"<h{level}>" + _inline_md_to_html(m.group(2)) + f"</h{level}>")
+            continue
+
+        m = re.match(r"^[-*•]\s+(.*)$", stripped)
+        if m:
+            flush_para()
+            if in_ol:
+                out.append("</ol>")
+                in_ol = False
+            if not in_ul:
+                out.append("<ul>")
+                in_ul = True
+            out.append("<li>" + _inline_md_to_html(m.group(1)) + "</li>")
+            continue
+
+        m = re.match(r"^\d+\.\s+(.*)$", stripped)
+        if m:
+            flush_para()
+            if in_ul:
+                out.append("</ul>")
+                in_ul = False
+            if not in_ol:
+                out.append("<ol>")
+                in_ol = True
+            out.append("<li>" + _inline_md_to_html(m.group(1)) + "</li>")
+            continue
+
+        close_lists()
+        para.append(_inline_md_to_html(stripped))
+
+    flush_para()
+    close_lists()
+    return "\n".join(out)
+
+
+def _md_to_html_basic(md: str) -> str:
+    """Minimal Markdown -> HTML converter for copy/paste purposes."""
+    md = (md or "").replace("\r\n", "\n")
+    parts = md.split("```")
+    out: List[str] = []
+
+    for i, part in enumerate(parts):
+        if i % 2 == 1:
+            code = html_escape(part.strip("\n"))
+            out.append("<pre><code>" + code + "</code></pre>")
+        else:
+            block_html = _md_block_to_html(part)
+            if block_html.strip():
+                out.append(block_html)
+
+    return "\n".join(out).strip()
+
+
+def build_conversation_html(messages: List[dict]) -> str:
+    """Rich transcript as HTML for clipboard copy."""
+    chunks: List[str] = ["<div>", "<p><strong>EphemerAl Conversation</strong></p>"]
+
+    for msg in messages:
+        role = msg.get("role", "assistant")
+        role_title = "User" if role == "user" else "Assistant"
+        chunks.append(f"<p><strong>{html_escape(role_title)}</strong></p>")
+
+        doc_lines, img_lines, message_text = _extract_export_info(msg.get("content", ""))
+
+        if doc_lines or img_lines:
+            chunks.append("<p><strong>Attachments:</strong></p>")
+            chunks.append("<ul>")
+            for line in (doc_lines + img_lines):
+                item = line.lstrip("- ").strip()
+                chunks.append("<li>" + _inline_md_to_html(item) + "</li>")
+            chunks.append("</ul>")
+
+        if message_text:
+            chunks.append(_md_to_html_basic(message_text))
+
+        chunks.append("<hr>")
+
+    chunks.append("</div>")
+    return "\n".join(chunks).strip()

--- a/ephemeral/stream_filter.py
+++ b/ephemeral/stream_filter.py
@@ -1,0 +1,78 @@
+import re
+from typing import List, Tuple
+
+
+class ThinkStreamFilter:
+    """Stateful filter for stripping streamed think/thought-channel blocks across chunks."""
+
+    def __init__(self) -> None:
+        self.in_think_block = False
+        self.current_think_close_tag = ""
+        self.stream_parse_buffer = ""
+        self.think_tag_pairs: List[Tuple[str, str]] = [
+            ("<|channel>thought\n", "<channel|>"),
+            ("<think>", "</think>"),
+        ]
+        self.open_tag_tail_len = max(len(open_tag) for open_tag, _ in self.think_tag_pairs) - 1
+        self.close_tag_tail_lens = {
+            close_tag: len(close_tag) - 1 for _, close_tag in self.think_tag_pairs
+        }
+
+    def process_chunk(self, delta: str) -> str:
+        if not delta:
+            return ""
+
+        output = ""
+        self.stream_parse_buffer += delta
+
+        while self.stream_parse_buffer:
+            if self.in_think_block:
+                close_idx = self.stream_parse_buffer.find(self.current_think_close_tag)
+                if close_idx == -1:
+                    close_tag_tail_len = self.close_tag_tail_lens[self.current_think_close_tag]
+                    if len(self.stream_parse_buffer) > close_tag_tail_len:
+                        self.stream_parse_buffer = self.stream_parse_buffer[-close_tag_tail_len:]
+                    break
+
+                self.stream_parse_buffer = self.stream_parse_buffer[
+                    close_idx + len(self.current_think_close_tag) :
+                ]
+                self.in_think_block = False
+                self.current_think_close_tag = ""
+                continue
+
+            nearest_open = None
+            for open_tag, close_tag in self.think_tag_pairs:
+                open_idx = self.stream_parse_buffer.find(open_tag)
+                if open_idx == -1:
+                    continue
+                if nearest_open is None or open_idx < nearest_open[0]:
+                    nearest_open = (open_idx, open_tag, close_tag)
+
+            if nearest_open is None:
+                if len(self.stream_parse_buffer) > self.open_tag_tail_len:
+                    output += self.stream_parse_buffer[:-self.open_tag_tail_len]
+                    self.stream_parse_buffer = self.stream_parse_buffer[-self.open_tag_tail_len:]
+                break
+
+            open_idx, open_tag, close_tag = nearest_open
+            output += self.stream_parse_buffer[:open_idx]
+            self.stream_parse_buffer = self.stream_parse_buffer[open_idx + len(open_tag) :]
+            self.in_think_block = True
+            self.current_think_close_tag = close_tag
+
+        return output
+
+    def finalize(self) -> str:
+        if self.stream_parse_buffer and not self.in_think_block:
+            tail = self.stream_parse_buffer
+            self.stream_parse_buffer = ""
+            return tail
+        self.stream_parse_buffer = ""
+        return ""
+
+
+def strip_think_blocks(text: str) -> str:
+    text = re.sub(r"<\|channel>thought\n.*?<channel\|>\s*", "", text, flags=re.DOTALL)
+    text = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
+    return text

--- a/ephemeral/token_budget.py
+++ b/ephemeral/token_budget.py
@@ -1,0 +1,7 @@
+from ephemeral.config import TOKEN_HEURISTIC_CHARS_PER_TOKEN
+
+
+def _heuristic_token_estimate(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, int(len(text) / TOKEN_HEURISTIC_CHARS_PER_TOKEN))

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -17,31 +17,47 @@ import requests
 import pytz
 from tika import parser
 from openai import OpenAI
+from ephemeral.config import (
+    APP_VERSION,
+    CONTEXT_PREFIX,
+    DEBUG_MODE,
+    ENABLE_TOKEN_BUDGETING,
+    IMG_TOKEN_COST_DEFAULT,
+    LLM_BASE_URL,
+    LLM_CONTEXT_TOKENS,
+    LLM_MAX_RETRIES,
+    LLM_MAX_TOKENS,
+    LLM_MODEL_NAME,
+    LLM_OUTPUT_RESERVE_TOKENS,
+    LLM_PRESENCE_PENALTY,
+    LLM_REASONING_EFFORT,
+    LLM_REQUEST_TIMEOUT_S,
+    LLM_SHOW_REASONING,
+    LLM_SUPPORTS_VISION,
+    LLM_TEMPERATURE,
+    LLM_TOP_P,
+    TIKA_CACHE_TTL_S,
+    TIKA_TIMEOUT_S,
+    TIKA_URL,
+    TOKEN_CACHE_MAX_ENTRIES,
+    TOKENIZE_TIMEOUT_S,
+    _ollama_base_url,
+)
+from ephemeral.export import (
+    _extract_export_info,
+    _inline_md_to_html,
+    _md_to_html_basic,
+    build_conversation_html,
+    build_conversation_markdown,
+    build_message_text,
+)
+from ephemeral.stream_filter import ThinkStreamFilter, strip_think_blocks
+from ephemeral.token_budget import _heuristic_token_estimate
 
 # EphemerAl main Streamlit application.
 # - Provides an ephemeral chat UI for working with uploaded documents and images.
 # - Talks to an LLM backend and an Apache Tika server over HTTP endpoints configured via environment variables.
 # - Uses Streamlit's in-memory session_state only, this script does not write chat content or uploads to disk.
-
-APP_VERSION = "1.8.1"
-
-# Prefix used for synthetic context blocks injected into user messages.
-# We use a flag (_synthetic) to identify these, not string matching.
-CONTEXT_PREFIX = "Context:\n"
-
-# TTL for session-scoped Tika parse cache (seconds)
-TIKA_CACHE_TTL_S = 3600
-
-# Token estimation behavior
-TOKEN_HEURISTIC_CHARS_PER_TOKEN = 3.5
-TOKEN_CACHE_MAX_ENTRIES = 256
-TOKENIZE_TIMEOUT_S = 2.0  # keep UI snappy; budgeting degrades silently if tokenize is slow/unavailable
-
-# Debug mode (shows technical status in sidebar, and error detail expanders)
-DEBUG_MODE = os.getenv("EPHEMERAL_DEBUG", "0").strip().lower() in {"1", "true", "yes", "y", "on"}
-
-# Feature toggle (operator-only)
-ENABLE_TOKEN_BUDGETING = os.getenv("ENABLE_TOKEN_BUDGETING", "1").strip().lower() not in {"0", "false", "no"}
 
 # ── Page config ───────────────────────────────────────────────────
 st.set_page_config(
@@ -69,81 +85,7 @@ except ImportError:
     device = None  # type: ignore
 
 # ── Backend configuration ─────────────────────────────────────────
-LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
-MODEL_NAME = os.getenv("LLM_MODEL_NAME", "ephemeral-default")
-TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")
-TIKA_TIMEOUT_S = int(os.getenv("TIKA_TIMEOUT_S", "15"))
 DEFAULT_UPLOAD_PROMPT = os.getenv("DEFAULT_UPLOAD_PROMPT", "Please analyze the uploaded files.")
-LLM_SUPPORTS_VISION = os.getenv("LLM_SUPPORTS_VISION")
-
-
-def _float_env(name: str, default: float) -> float:
-    """Parse a float env var with safe fallback on missing/blank/invalid values."""
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    raw = raw.strip()
-    if not raw:
-        return default
-    try:
-        return float(raw)
-    except Exception:
-        return default
-
-
-def _int_env_optional(name: str) -> Optional[int]:
-    """Parse an optional int env var; return None for missing/blank/invalid/non-positive values."""
-    raw = os.getenv(name)
-    if raw is None:
-        return None
-    raw = raw.strip()
-    if not raw:
-        return None
-    try:
-        value = int(raw)
-        return value if value > 0 else None
-    except Exception:
-        return None
-
-
-def _int_env(name: str, default: int) -> int:
-    """Parse an int env var with safe fallback on missing/blank/invalid values."""
-    value = _int_env_optional(name)
-    return value if value is not None else default
-
-
-def _bool_env(name: str, default: bool = False) -> bool:
-    """Parse a bool env var with safe fallback on missing/blank/invalid values."""
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    value = raw.strip().lower()
-    if value in {"1", "true", "yes", "y", "on"}:
-        return True
-    if value in {"0", "false", "no", "n", "off"}:
-        return False
-    return default
-
-
-LLM_CONTEXT_TOKENS = _int_env_optional("LLM_CONTEXT_TOKENS")
-LLM_OUTPUT_RESERVE_TOKENS = _int_env("LLM_OUTPUT_RESERVE_TOKENS", 32768)
-LLM_REQUEST_TIMEOUT_S = _float_env("LLM_REQUEST_TIMEOUT_S", 1800.0)
-LLM_MAX_RETRIES = _int_env("LLM_MAX_RETRIES", 0)
-LLM_TEMPERATURE = _float_env("LLM_TEMPERATURE", 0.7)
-LLM_TOP_P = _float_env("LLM_TOP_P", 0.8)
-LLM_PRESENCE_PENALTY = _float_env("LLM_PRESENCE_PENALTY", 1.5)
-LLM_REASONING_EFFORT = os.getenv("LLM_REASONING_EFFORT", "none").strip() or "none"
-LLM_SHOW_REASONING = _bool_env("LLM_SHOW_REASONING", False)
-LLM_MAX_TOKENS = _int_env_optional("LLM_MAX_TOKENS")
-IMG_TOKEN_COST_DEFAULT = _int_env("IMG_TOKEN_COST_DEFAULT", 2048)
-
-
-def _ollama_base_url() -> str:
-    """
-    Convert an OpenAI-style base URL like http://host:11434/v1 into the native Ollama base http://host:11434.
-    If /v1 isn't present, returns the URL without trailing slash.
-    """
-    return LLM_BASE_URL.rstrip("/").split("/v1")[0]
 
 
 # ── Health checks (cached to reduce UI jank) ──────────────────────
@@ -293,7 +235,7 @@ def _ollama_show() -> Optional[Dict]:
     """Cached wrapper for Ollama /api/show. Returns JSON dict on success, else None."""
     try:
         show_url = f"{_ollama_base_url()}/api/show"
-        resp = requests.post(show_url, json={"model": MODEL_NAME}, timeout=2)
+        resp = requests.post(show_url, json={"model": LLM_MODEL_NAME}, timeout=2)
         if resp.ok:
             return resp.json()
     except Exception as e:
@@ -398,12 +340,6 @@ def get_image_token_cost() -> int:
 
 
 # ── Token counting ────────────────────────────────────────────────
-def _heuristic_token_estimate(text: str) -> int:
-    if not text:
-        return 0
-    return max(1, int(len(text) / TOKEN_HEURISTIC_CHARS_PER_TOKEN))
-
-
 def _get_token_cache() -> Dict[str, int]:
     return st.session_state.setdefault("_token_count_cache", {})
 
@@ -442,7 +378,7 @@ def count_text_tokens(text: str) -> int:
     try:
         resp = requests.post(
             tokenize_url,
-            json={"model": MODEL_NAME, "content": text},
+            json={"model": LLM_MODEL_NAME, "content": text},
             timeout=TOKENIZE_TIMEOUT_S,
         )
 
@@ -481,257 +417,6 @@ def styled_chat_message(role: str, message_id: str = None):
     """Return a chat_message wrapped in a keyed container for CSS styling."""
     key = f"{role}-{message_id}" if message_id else f"{role}-{uuid.uuid4()}"
     return st.container(key=key).chat_message(role)
-
-
-def build_message_text(messages: List[dict]) -> str:
-    """Flatten message content into text for token estimation."""
-    chunks: List[str] = []
-    for msg in messages:
-        content = msg.get("content", "")
-        if isinstance(content, list):
-            for part in content:
-                if part.get("type") == "text":
-                    text = part.get("text")
-                    if text:
-                        chunks.append(text)
-        else:
-            if content:
-                chunks.append(str(content))
-    return "\n".join(chunks)
-
-
-# ── Copy helpers (sidebar-only) ───────────────────────────────────
-def _extract_export_info(content: Union[str, list]) -> Tuple[List[str], List[str], str]:
-    """
-    Extract (doc_lines, img_lines, message_text) from message content.
-
-    Notes:
-    - We do NOT export the full extracted document text from Context:, only filenames and counts.
-    - Synthetic context parts (marked with _synthetic flag) are parsed for metadata only.
-    """
-    doc_lines: List[str] = []
-    img_lines: List[str] = []
-    text_chunks: List[str] = []
-
-    if not isinstance(content, list):
-        return doc_lines, img_lines, "" if content is None else str(content)
-
-    doc_seen = set()
-    img_seen = set()
-    img_marker_names: List[str] = []
-
-    for part in content:
-        ptype = part.get("type")
-
-        if ptype == "text":
-            text = part.get("text", "")
-
-            if part.get("_synthetic"):
-                ctx = text[len(CONTEXT_PREFIX) :] if text.startswith(CONTEXT_PREFIX) else text
-                blocks = re.split(r"(?m)^---\s*(.+?)\s*---\s*$", ctx)
-                for i in range(1, len(blocks), 2):
-                    fname = (blocks[i] or "").strip()
-                    extracted = blocks[i + 1] if i + 1 < len(blocks) else ""
-                    char_count = len((extracted or "").strip())
-                    if fname and fname not in doc_seen:
-                        doc_seen.add(fname)
-                        doc_lines.append(f"- 📄 {fname} ({char_count:,} characters extracted)")
-
-            elif text.startswith("📄 *") and text.endswith("*"):
-                fname = text[len("📄 *") : -1].strip()
-                if fname and fname not in doc_seen:
-                    doc_seen.add(fname)
-                    doc_lines.append(f"- 📄 {fname}")
-
-            elif text.startswith("📷 *") and text.endswith("*"):
-                fname = text[len("📷 *") : -1].strip()
-                if fname:
-                    img_marker_names.append(fname)
-
-            else:
-                if text and text.strip():
-                    text_chunks.append(text.strip())
-
-        elif ptype == "image":
-            fname = (part.get("filename") or "image").strip()
-            if fname and fname not in img_seen:
-                img_seen.add(fname)
-                img_lines.append(f"- 📷 {fname}")
-
-        elif ptype == "image_url":
-            fname = (part.get("filename") or "image").strip()
-            if fname and fname not in img_seen:
-                img_seen.add(fname)
-                img_lines.append(f"- 📷 {fname}")
-
-    for fname in img_marker_names:
-        if fname not in img_seen:
-            img_seen.add(fname)
-            img_lines.append(f"- 📷 {fname}")
-
-    message_text = "\n\n".join(text_chunks).strip()
-    return doc_lines, img_lines, message_text
-
-
-def build_conversation_markdown(messages: List[dict]) -> str:
-    """Build a Markdown transcript used as plain-text clipboard fallback."""
-    lines: List[str] = ["# EphemerAl Conversation", ""]
-
-    for msg in messages:
-        role = msg.get("role", "assistant")
-        role_title = "User" if role == "user" else "Assistant"
-        lines.append(f"**{role_title}**")
-
-        doc_lines, img_lines, message_text = _extract_export_info(msg.get("content", ""))
-
-        if doc_lines or img_lines:
-            lines.append("")
-            lines.append("Attachments:")
-            lines.extend(doc_lines)
-            lines.extend(img_lines)
-
-        if message_text:
-            lines.append("")
-            lines.append(message_text)
-
-        lines.append("")
-        lines.append("---")
-        lines.append("")
-
-    return "\n".join(lines).rstrip() + "\n"
-
-
-def _inline_md_to_html(text: str) -> str:
-    """Minimal inline Markdown -> HTML for clipboard friendliness."""
-    t = html_escape(text)
-    t = re.sub(r"`([^`]+)`", r"<code>\1</code>", t)
-    t = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", t)
-    t = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", t)
-    return t
-
-
-def _md_block_to_html(md_block: str) -> str:
-    """Minimal block Markdown -> HTML for clipboard friendliness."""
-    md_block = (md_block or "").replace("\r\n", "\n")
-    lines = md_block.split("\n")
-
-    out: List[str] = []
-    para: List[str] = []
-    in_ul = False
-    in_ol = False
-
-    def flush_para() -> None:
-        nonlocal para
-        if para:
-            out.append("<p>" + "<br>".join(para) + "</p>")
-            para = []
-
-    def close_lists() -> None:
-        nonlocal in_ul, in_ol
-        if in_ul:
-            out.append("</ul>")
-            in_ul = False
-        if in_ol:
-            out.append("</ol>")
-            in_ol = False
-
-    for raw in lines:
-        stripped = (raw or "").strip()
-
-        if stripped == "":
-            flush_para()
-            continue
-
-        if stripped in {"---", "***", "___"}:
-            flush_para()
-            close_lists()
-            out.append("<hr>")
-            continue
-
-        m = re.match(r"^(#{1,6})\s+(.*)$", stripped)
-        if m:
-            flush_para()
-            close_lists()
-            level = len(m.group(1))
-            out.append(f"<h{level}>" + _inline_md_to_html(m.group(2)) + f"</h{level}>")
-            continue
-
-        m = re.match(r"^[-*•]\s+(.*)$", stripped)
-        if m:
-            flush_para()
-            if in_ol:
-                out.append("</ol>")
-                in_ol = False
-            if not in_ul:
-                out.append("<ul>")
-                in_ul = True
-            out.append("<li>" + _inline_md_to_html(m.group(1)) + "</li>")
-            continue
-
-        m = re.match(r"^\d+\.\s+(.*)$", stripped)
-        if m:
-            flush_para()
-            if in_ul:
-                out.append("</ul>")
-                in_ul = False
-            if not in_ol:
-                out.append("<ol>")
-                in_ol = True
-            out.append("<li>" + _inline_md_to_html(m.group(1)) + "</li>")
-            continue
-
-        close_lists()
-        para.append(_inline_md_to_html(stripped))
-
-    flush_para()
-    close_lists()
-    return "\n".join(out)
-
-
-def _md_to_html_basic(md: str) -> str:
-    """Minimal Markdown -> HTML converter for copy/paste purposes."""
-    md = (md or "").replace("\r\n", "\n")
-    parts = md.split("```")
-    out: List[str] = []
-
-    for i, part in enumerate(parts):
-        if i % 2 == 1:
-            code = html_escape(part.strip("\n"))
-            out.append("<pre><code>" + code + "</code></pre>")
-        else:
-            block_html = _md_block_to_html(part)
-            if block_html.strip():
-                out.append(block_html)
-
-    return "\n".join(out).strip()
-
-
-def build_conversation_html(messages: List[dict]) -> str:
-    """Rich transcript as HTML for clipboard copy."""
-    chunks: List[str] = ["<div>", "<p><strong>EphemerAl Conversation</strong></p>"]
-
-    for msg in messages:
-        role = msg.get("role", "assistant")
-        role_title = "User" if role == "user" else "Assistant"
-        chunks.append(f"<p><strong>{html_escape(role_title)}</strong></p>")
-
-        doc_lines, img_lines, message_text = _extract_export_info(msg.get("content", ""))
-
-        if doc_lines or img_lines:
-            chunks.append("<p><strong>Attachments:</strong></p>")
-            chunks.append("<ul>")
-            for line in (doc_lines + img_lines):
-                item = line.lstrip("- ").strip()
-                chunks.append("<li>" + _inline_md_to_html(item) + "</li>")
-            chunks.append("</ul>")
-
-        if message_text:
-            chunks.append(_md_to_html_basic(message_text))
-
-        chunks.append("<hr>")
-
-    chunks.append("</div>")
-    return "\n".join(chunks).strip()
 
 
 def render_copy_button(export_text_plain: str, export_html: str) -> None:
@@ -917,7 +602,7 @@ with st.sidebar:
             dbg_reserved_ctx = min(LLM_OUTPUT_RESERVE_TOKENS, int(dbg_effective_ctx * 0.25))
             dbg_budget_ctx = max(4096, dbg_usable_ctx - dbg_reserved_ctx)
             st.caption(f"App version: {APP_VERSION}")
-            st.caption(f"Model: {MODEL_NAME}")
+            st.caption(f"Model: {LLM_MODEL_NAME}")
             st.caption(f"LLM base URL: {LLM_BASE_URL}")
             st.caption(
                 "Context budget: "
@@ -1294,7 +979,7 @@ if prompt_in is not None:
             try:
                 client = get_llm_client()
                 request_kwargs = {
-                    "model": MODEL_NAME,
+                    "model": LLM_MODEL_NAME,
                     "messages": payload,
                     "stream": True,
                     "temperature": LLM_TEMPERATURE,
@@ -1322,19 +1007,7 @@ if prompt_in is not None:
                 acc = ""
                 box = st.empty()
                 used_usage_from_backend = False
-                in_think_block = False
-                current_think_close_tag = ""
-                stream_parse_buffer = ""
-                # Filter both legacy (<think>...</think>) and channel-tag
-                # (<|channel>thought\n...<channel|>) think-block formats.
-                think_tag_pairs = [
-                    ("<|channel>thought\n", "<channel|>"),
-                    ("<think>", "</think>"),
-                ]
-                open_tag_tail_len = max(len(open_tag) for open_tag, _ in think_tag_pairs) - 1
-                close_tag_tail_lens = {
-                    close_tag: len(close_tag) - 1 for _, close_tag in think_tag_pairs
-                }
+                stream_filter = ThinkStreamFilter()
 
                 for chunk in stream:
                     if getattr(chunk, "choices", None):
@@ -1343,44 +1016,7 @@ if prompt_in is not None:
                         if not delta and LLM_SHOW_REASONING:
                             delta = getattr(delta_obj, "reasoning", None)
                         if delta:
-                            stream_parse_buffer += delta
-
-                            while stream_parse_buffer:
-                                if in_think_block:
-                                    close_idx = stream_parse_buffer.find(current_think_close_tag)
-                                    if close_idx == -1:
-                                        close_tag_tail_len = close_tag_tail_lens[current_think_close_tag]
-                                        if len(stream_parse_buffer) > close_tag_tail_len:
-                                            stream_parse_buffer = stream_parse_buffer[-close_tag_tail_len:]
-                                        break
-
-                                    stream_parse_buffer = stream_parse_buffer[
-                                        close_idx + len(current_think_close_tag) :
-                                    ]
-                                    in_think_block = False
-                                    current_think_close_tag = ""
-                                    continue
-
-                                nearest_open = None
-                                for open_tag, close_tag in think_tag_pairs:
-                                    open_idx = stream_parse_buffer.find(open_tag)
-                                    if open_idx == -1:
-                                        continue
-                                    if nearest_open is None or open_idx < nearest_open[0]:
-                                        nearest_open = (open_idx, open_tag, close_tag)
-
-                                if nearest_open is None:
-                                    if len(stream_parse_buffer) > open_tag_tail_len:
-                                        acc += stream_parse_buffer[:-open_tag_tail_len]
-                                        stream_parse_buffer = stream_parse_buffer[-open_tag_tail_len:]
-                                    break
-
-                                open_idx, open_tag, close_tag = nearest_open
-                                acc += stream_parse_buffer[:open_idx]
-                                stream_parse_buffer = stream_parse_buffer[open_idx + len(open_tag) :]
-                                in_think_block = True
-                                current_think_close_tag = close_tag
-
+                            acc += stream_filter.process_chunk(delta)
                             box.markdown(acc + "▌")
 
                     usage = getattr(chunk, "usage", None)
@@ -1388,19 +1024,18 @@ if prompt_in is not None:
                         st.session_state.last_token_count = int(usage.total_tokens)
                         used_usage_from_backend = True
 
-                if in_think_block and DEBUG_MODE:
+                if stream_filter.in_think_block and DEBUG_MODE:
                     logging.debug("Unclosed think block detected at end of stream.")
 
-                if stream_parse_buffer:
-                    if not in_think_block:
-                        acc += stream_parse_buffer
-                    elif DEBUG_MODE:
-                        logging.debug(
-                            "Discarding trailing stream buffer because stream ended inside a think block."
-                        )
+                tail = stream_filter.finalize()
+                if tail:
+                    acc += tail
+                elif stream_filter.in_think_block and DEBUG_MODE:
+                    logging.debug(
+                        "Discarding trailing stream buffer because stream ended inside a think block."
+                    )
 
-                acc = re.sub(r"<\|channel>thought\n.*?<channel\|>\s*", "", acc, flags=re.DOTALL)
-                acc = re.sub(r"<think>.*?</think>\s*", "", acc, flags=re.DOTALL)
+                acc = strip_think_blocks(acc)
                 box.markdown(acc)
 
                 # If backend didn't provide usage totals, keep hybrid behavior with a fast estimate.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pytest-cov>=5.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,77 @@
+from ephemeral import config
+
+
+def test_float_env_valid_invalid_blank_missing(monkeypatch):
+    monkeypatch.setenv("X_FLOAT", " 1.25 ")
+    assert config._float_env("X_FLOAT", 9.0) == 1.25
+
+    monkeypatch.setenv("X_FLOAT", "")
+    assert config._float_env("X_FLOAT", 9.0) == 9.0
+
+    monkeypatch.setenv("X_FLOAT", "abc")
+    assert config._float_env("X_FLOAT", 9.0) == 9.0
+
+    monkeypatch.delenv("X_FLOAT", raising=False)
+    assert config._float_env("X_FLOAT", 9.0) == 9.0
+
+
+def test_int_env_optional_cases(monkeypatch):
+    monkeypatch.setenv("X_INT_OPT", " 42 ")
+    assert config._int_env_optional("X_INT_OPT") == 42
+
+    monkeypatch.setenv("X_INT_OPT", "0")
+    assert config._int_env_optional("X_INT_OPT") is None
+
+    monkeypatch.setenv("X_INT_OPT", "-5")
+    assert config._int_env_optional("X_INT_OPT") is None
+
+    monkeypatch.setenv("X_INT_OPT", "")
+    assert config._int_env_optional("X_INT_OPT") is None
+
+    monkeypatch.setenv("X_INT_OPT", "oops")
+    assert config._int_env_optional("X_INT_OPT") is None
+
+    monkeypatch.delenv("X_INT_OPT", raising=False)
+    assert config._int_env_optional("X_INT_OPT") is None
+
+
+def test_int_env_with_default(monkeypatch):
+    monkeypatch.setenv("X_INT", "10")
+    assert config._int_env("X_INT", 7) == 10
+
+    monkeypatch.setenv("X_INT", "")
+    assert config._int_env("X_INT", 7) == 7
+
+    monkeypatch.setenv("X_INT", "bad")
+    assert config._int_env("X_INT", 7) == 7
+
+
+def test_bool_env_variants(monkeypatch):
+    for raw in ["1", "true", "yes", "y", "on", "  YES  "]:
+        monkeypatch.setenv("X_BOOL", raw)
+        assert config._bool_env("X_BOOL", False) is True
+
+    for raw in ["0", "false", "no", "n", "off", " Off "]:
+        monkeypatch.setenv("X_BOOL", raw)
+        assert config._bool_env("X_BOOL", True) is False
+
+    monkeypatch.setenv("X_BOOL", "maybe")
+    assert config._bool_env("X_BOOL", True) is True
+    assert config._bool_env("X_BOOL", False) is False
+
+    monkeypatch.delenv("X_BOOL", raising=False)
+    assert config._bool_env("X_BOOL", True) is True
+
+
+def test_ollama_base_url_variants(monkeypatch):
+    monkeypatch.setattr(config, "LLM_BASE_URL", "http://ollama:11434/v1")
+    assert config._ollama_base_url() == "http://ollama:11434"
+
+    monkeypatch.setattr(config, "LLM_BASE_URL", "http://ollama:11434/v1/")
+    assert config._ollama_base_url() == "http://ollama:11434"
+
+    monkeypatch.setattr(config, "LLM_BASE_URL", "http://ollama:11434")
+    assert config._ollama_base_url() == "http://ollama:11434"
+
+    monkeypatch.setattr(config, "LLM_BASE_URL", "http://ollama:11434/")
+    assert config._ollama_base_url() == "http://ollama:11434"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,91 @@
+from ephemeral.export import (
+    _extract_export_info,
+    _md_to_html_basic,
+    build_conversation_html,
+    build_conversation_markdown,
+)
+
+
+def test_extract_export_info_plain_and_none():
+    assert _extract_export_info("hello") == ([], [], "hello")
+    assert _extract_export_info(None) == ([], [], "")
+
+
+def test_extract_export_info_multipart_with_images_docs_and_synthetic_context():
+    content = [
+        {
+            "type": "text",
+            "text": "Context:\n--- alpha.pdf ---\nabc\n\n--- beta.docx ---\n12345\n",
+            "_synthetic": True,
+        },
+        {"type": "text", "text": "📄 *manual.txt*"},
+        {"type": "text", "text": "📄 *manual.txt*"},
+        {"type": "text", "text": "📷 *photo.png*"},
+        {"type": "image", "filename": "photo.png"},
+        {"type": "image_url", "filename": "scan.jpg"},
+        {"type": "text", "text": "  user note  "},
+        {"type": "text", "text": ""},
+    ]
+
+    docs, imgs, text = _extract_export_info(content)
+    assert "- 📄 alpha.pdf (3 characters extracted)" in docs
+    assert "- 📄 beta.docx (5 characters extracted)" in docs
+    assert "- 📄 manual.txt" in docs
+    assert imgs == ["- 📷 photo.png", "- 📷 scan.jpg"]
+    assert text == "user note"
+
+
+def test_markdown_and_html_build_and_escape():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "📄 *doc1.pdf*"},
+                {"type": "text", "text": "hello **world**"},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "<script>alert(1)</script>\n\n<div>content</div>",
+        },
+    ]
+
+    md = build_conversation_markdown(messages)
+    assert "# EphemerAl Conversation" in md
+    assert "**User**" in md
+    assert "Attachments:" in md
+    assert "- 📄 doc1.pdf" in md
+
+    html = build_conversation_html(messages)
+    assert "<strong>User</strong>" in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "&lt;div&gt;content&lt;/div&gt;" in html
+    assert "<script>" not in html
+
+
+def test_md_to_html_basic_formats():
+    md = """# Heading
+
+Paragraph with **bold**, *italic*, and `code` plus & entity.
+
+- item 1
+- item 2
+
+1. first
+2. second
+
+---
+
+```python
+print('x')
+```
+"""
+    html = _md_to_html_basic(md)
+    assert "<h1>Heading</h1>" in html
+    assert "<strong>bold</strong>" in html
+    assert "<em>italic</em>" in html
+    assert "<code>code</code>" in html
+    assert "&amp; entity" in html
+    assert "<ul>" in html and "<ol>" in html
+    assert "<hr>" in html
+    assert "<pre><code>python\nprint(&#x27;x&#x27;)</code></pre>" in html

--- a/tests/test_stream_filter.py
+++ b/tests/test_stream_filter.py
@@ -1,0 +1,43 @@
+from ephemeral.stream_filter import ThinkStreamFilter, strip_think_blocks
+
+
+def _run_chunks(chunks):
+    f = ThinkStreamFilter()
+    out = ""
+    for c in chunks:
+        out += f.process_chunk(c)
+    out += f.finalize()
+    return out, f
+
+
+def test_complete_think_block_stripped():
+    out, _ = _run_chunks(["hello <think>secret</think> world"])
+    assert out == "hello  world"
+
+
+def test_complete_channel_thought_block_stripped():
+    out, _ = _run_chunks(["a<|channel>thought\nsecret<channel|>b"])
+    assert out == "ab"
+
+
+def test_split_chunks_tag_boundaries():
+    out, _ = _run_chunks(["hello <thi", "nk>secret</th", "ink> world"])
+    assert out == "hello  world"
+
+
+def test_unclosed_think_block_end_of_stream():
+    out, f = _run_chunks(["safe <think>secret forever"])
+    assert out == "safe "
+    assert f.in_think_block is True
+
+
+def test_content_outside_blocks_unchanged_and_multiple_blocks():
+    out, _ = _run_chunks([
+        "A<think>x</think>B<|channel>thought\ny<channel|>C<think>z</think>D"
+    ])
+    assert out == "ABCD"
+
+
+def test_post_strip_defense_in_depth():
+    assert strip_think_blocks("a<think>b</think>c") == "ac"
+    assert strip_think_blocks("a<|channel>thought\nb<channel|>c") == "ac"

--- a/tests/test_token_budget.py
+++ b/tests/test_token_budget.py
@@ -1,0 +1,10 @@
+from ephemeral.token_budget import _heuristic_token_estimate
+
+
+def test_heuristic_token_estimate_ranges():
+    assert _heuristic_token_estimate("") == 0
+    assert _heuristic_token_estimate("a") >= 1
+    assert _heuristic_token_estimate("hello world") >= 1
+    short = _heuristic_token_estimate("x" * 20)
+    long = _heuristic_token_estimate("x" * 2000)
+    assert long > short


### PR DESCRIPTION
### Motivation
- Make pure utility code import-safe so `ephemeral_app.py` can be imported in tests without Streamlit side-effects. 
- Enable automated unit testing for env parsing, export rendering, think-block filtering and token heuristics.

### Description
- Added an import-safe `ephemeral/` package with extracted modules: `ephemeral/config.py` (env helpers, constants, `_ollama_base_url`), `ephemeral/export.py` (export/Markdown→HTML builders, `build_message_text`, `_extract_export_info`, `_inline_md_to_html`, `_md_block_to_html`, `_md_to_html_basic`, `build_conversation_*`), `ephemeral/stream_filter.py` (`ThinkStreamFilter` stateful chunk filter and `strip_think_blocks`), and `ephemeral/token_budget.py` (`_heuristic_token_estimate`).
- Updated `ephemeral_app.py` to import and use the extracted utilities (preserving behavior and LLM defaults), and replaced the inline streaming think-block parser with the `ThinkStreamFilter` plus final defense-in-depth `strip_think_blocks` call.
- Added a minimal test infrastructure: `tests/` with pytest tests covering config/env parsing (`_float_env`, `_int_env*`, `_bool_env`, `_ollama_base_url`), export parsing and escaping (`_extract_export_info`, `build_conversation_markdown`, `build_conversation_html`, `_md_to_html_basic`), think-block streaming behavior (`ThinkStreamFilter` & `strip_think_blocks`), and token heuristic (`_heuristic_token_estimate`).
- Added `requirements-dev.txt` (dev deps only) and updated `AGENTS.md` to list the new files and the test command and to require `ephemeral/` modules be import-safe.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and `python -m py_compile ephemeral/*.py`, which succeeded. 
- Ran the test suite with `python -m pytest`, which completed with all tests green (`16 passed`).
- Attempted `pip install -r requirements-dev.txt`; `pytest` installed, but fetching `pytest-cov` failed in this environment due to an external proxy/index error (tests still ran successfully with the available `pytest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead82afd088328879fd958e8924b71)