### PR TITLE
Post-review cleanup: remove dead imports, harden TIKA parsing, update docs and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,3 +45,5 @@ System Deployment Guide.md
 Ephemeral Screenshot.jpg
 docker-compose.yml
 docker-compose.api.yml
+tests/
+requirements-dev.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ frontend, an Ollama LLM backend, and an Apache Tika document parsing server.
 
 ## Key Files
 - `ephemeral_app.py` — Main application. All state is in-memory (session_state).
-- `ephemeral/` — Import-safe utility package (no Streamlit side effects at import time).
+- `ephemeral/` — Mixed package: pure utility modules (`config`, `export`, `stream_filter`, `token_budget`) are import-safe with no Streamlit dependency, while client modules (`tika_client`, `llm_client`) are Streamlit-aware by design.
 - `ephemeral/config.py` — Env parsing helpers and shared configuration constants.
 - `ephemeral/export.py` — Conversation transcript/export builders (Markdown/HTML).
 - `ephemeral/tika_client.py` — Tika health check and document parsing client helpers.
@@ -119,8 +119,11 @@ When reviewing Codex changes, treat the following as high-priority checks:
   guide should point to files that exist in the repo.
 - Full stack test: `docker compose up -d --build` inside WSL2, then access
   `http://localhost:8501`.
-- Keep `ephemeral/` modules import-safe: no Streamlit imports or Streamlit side effects
-  at import time.
+- Keep pure utility modules import-safe (`config`, `export`, `stream_filter`,
+  `token_budget`): no Streamlit imports or Streamlit side effects at import time, so
+  tests run without Streamlit.
+- `ephemeral/tika_client.py` and `ephemeral/llm_client.py` are Streamlit-aware by
+  design and may use Streamlit caching decorators/session state.
 
 ## Do Not
 - Do not change environment variable defaults in `ephemeral_app.py` to use `localhost`.

--- a/ephemeral/config.py
+++ b/ephemeral/config.py
@@ -24,7 +24,6 @@ ENABLE_TOKEN_BUDGETING = os.getenv("ENABLE_TOKEN_BUDGETING", "1").strip().lower(
 LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
 LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "ephemeral-default")
 TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")
-TIKA_TIMEOUT_S = int(os.getenv("TIKA_TIMEOUT_S", "15"))
 LLM_SUPPORTS_VISION = os.getenv("LLM_SUPPORTS_VISION")
 
 
@@ -76,6 +75,7 @@ def _bool_env(name: str, default: bool = False) -> bool:
     return default
 
 
+TIKA_TIMEOUT_S = _int_env("TIKA_TIMEOUT_S", 15)
 LLM_CONTEXT_TOKENS = _int_env_optional("LLM_CONTEXT_TOKENS")
 LLM_OUTPUT_RESERVE_TOKENS = _int_env("LLM_OUTPUT_RESERVE_TOKENS", 32768)
 LLM_REQUEST_TIMEOUT_S = _float_env("LLM_REQUEST_TIMEOUT_S", 1800.0)

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -29,9 +29,6 @@ from ephemeral.config import (
     TIKA_URL,
 )
 from ephemeral.export import (
-    _extract_export_info,
-    _inline_md_to_html,
-    _md_to_html_basic,
     build_conversation_html,
     build_conversation_markdown,
     build_message_text,


### PR DESCRIPTION
### Motivation
- Clean up minor issues found during a post-review pass after modularizing the repo to reduce noise and harden runtime behavior.
- Prevent development/test files from being included in production Docker images and clarify import-safety expectations in the project docs.

### Description
- Removed unused internal export helper imports (`_extract_export_info`, `_inline_md_to_html`, `_md_to_html_basic`) from the `ephemeral.export` import block in `ephemeral_app.py` so only the public builders used by the app are imported.
- Switched `TIKA_TIMEOUT_S` parsing in `ephemeral/config.py` to use the safe helper `_int_env("TIKA_TIMEOUT_S", 15)` so invalid env values fall back instead of raising at import time.
- Added `tests/` and `requirements-dev.txt` to `.dockerignore` to exclude development/test artifacts from the Docker build context.
- Updated `AGENTS.md` to distinguish pure utility modules (import-safe: `config`, `export`, `stream_filter`, `token_budget`) from Streamlit-aware client modules (`tika_client`, `llm_client`) and clarified the testing guidance accordingly.

### Testing
- Ran `python -m py_compile ephemeral_app.py` and it succeeded.
- Ran `python -m py_compile ephemeral/config.py` and it succeeded.
- Ran the test suite with `python -m pytest` which completed successfully (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae11d2be08328a2a31500c509499c)