### PR TITLE
Show uploaded attachments as badges and refine chat UI styling

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -454,12 +454,50 @@ def render_content(content: Union[str, list]) -> None:
     Render either plain markdown or structured content (text + images).
     Synthetic context blocks (marked with _synthetic flag) are hidden from display.
     """
+    def _format_file_size(num_bytes: int) -> str:
+        if num_bytes <= 0:
+            return ""
+        units = ["B", "KB", "MB", "GB"]
+        size = float(num_bytes)
+        unit_idx = 0
+        while size >= 1024 and unit_idx < len(units) - 1:
+            size /= 1024.0
+            unit_idx += 1
+        if unit_idx == 0:
+            return f"{int(size)} {units[unit_idx]}"
+        return f"{size:.1f} {units[unit_idx]}"
+
+    def _render_attachment_badge(meta: dict) -> None:
+        filename = html_escape(meta.get("name", "Attachment"))
+        size_label = _format_file_size(int(meta.get("size", 0) or 0))
+        kind = meta.get("kind", "document")
+        icon = "🖼️" if kind == "image" else "📄"
+        subtitle = f"{kind.title()} upload"
+        if size_label:
+            subtitle = f"{subtitle} • {size_label}"
+        st.markdown(
+            (
+                '<div class="attachment-card" role="group" aria-label="Uploaded file">'
+                f'<div class="attachment-icon">{icon}</div>'
+                '<div class="attachment-copy">'
+                f'<div class="attachment-name">{filename}</div>'
+                f'<div class="attachment-meta">{html_escape(subtitle)}</div>'
+                "</div>"
+                "</div>"
+            ),
+            unsafe_allow_html=True,
+        )
+
     if isinstance(content, list):
         for part in content:
             ptype = part.get("type")
             if ptype == "text":
                 if not part.get("_synthetic"):
-                    st.markdown(part.get("text", ""))
+                    attachment = part.get("_attachment")
+                    if attachment:
+                        _render_attachment_badge(attachment)
+                    else:
+                        st.markdown(part.get("text", ""))
             elif ptype == "image":
                 try:
                     st.image(part.get("data"), width=180)
@@ -559,20 +597,33 @@ if prompt_in is not None:
         if ftype.startswith("image/"):
             f.seek(0)
             img_bytes = f.getvalue()
-            parts.append({"type": "text", "text": f"📷 *{f.name}*"})
+            parts.append(
+                {
+                    "type": "text",
+                    "text": f"📷 *{f.name}*",
+                    "_attachment": {"name": f.name, "size": file_size, "kind": "image"},
+                }
+            )
             parts.append(
                 {
                     "type": "image",
                     "data": img_bytes,
                     "mime_type": ftype or "image/jpeg",
                     "filename": f.name,
+                    "size": file_size,
                 }
             )
             image_count += 1
             continue
 
         # Document-like file
-        parts.append({"type": "text", "text": f"📄 *{f.name}*"})
+        parts.append(
+            {
+                "type": "text",
+                "text": f"📄 *{f.name}*",
+                "_attachment": {"name": f.name, "size": file_size, "kind": "document"},
+            }
+        )
         if not tika_ok:
             continue
 

--- a/theme.css
+++ b/theme.css
@@ -355,21 +355,123 @@ button[title="View fullscreen"] {
 
 /* Streamlit internal test IDs for chat blocks in 1.56. */
 [data-testid="stChatMessage"] {
-    border-radius: 14px;
-    padding: 0.12rem 0.15rem;
+    border-radius: 16px;
+    padding: 0.12rem 0.2rem;
     border: 1px solid var(--color-border);
-    box-shadow: 0 3px 12px rgba(24, 35, 65, 0.05);
+    box-shadow: 0 4px 14px rgba(24, 35, 65, 0.05);
+    margin-bottom: 0.35rem;
 }
 
 /* Preserve role wrapper architecture from st-key-{role}- containers. */
 [class*="st-key-user-"] [data-testid="stChatMessage"] {
     background: var(--color-user-msg-bg) !important;
-    border-left: 3px solid var(--color-user-msg-border);
+    border: 1px solid #d8defb !important;
+    border-radius: 16px !important;
+    box-shadow: 0 4px 14px rgba(68, 84, 170, 0.08) !important;
+}
+
+/* Streamlit internal structure: user row wrapper to emulate right aligned bubbles + avatar. */
+[class*="st-key-user-"] [data-testid="stChatMessage"] > div {
+    flex-direction: row-reverse;
+    justify-content: flex-start;
+    gap: 0.65rem;
+}
+
+/* Streamlit internal test ID: content wrapper inside chat message in 1.56. */
+[class*="st-key-user-"] [data-testid="stChatMessageContent"] {
+    margin-left: auto;
+    text-align: left;
+    background: linear-gradient(180deg, #f0f3ff 0%, #e9eeff 100%);
+    border-radius: 16px;
+    border: 1px solid #d7defe;
+    padding: 0.72rem 0.9rem;
+    max-width: min(86%, 760px);
 }
 
 [class*="st-key-assistant-"] [data-testid="stChatMessage"] {
     background: var(--color-asst-msg-bg) !important;
-    border-left: 3px solid var(--color-asst-msg-border);
+    border: 1px solid #dbe1ef !important;
+    border-left: 4px solid var(--color-asst-msg-border) !important;
+    box-shadow: 0 5px 16px rgba(30, 44, 77, 0.07) !important;
+}
+
+/* Streamlit internal test ID: content wrapper inside chat message in 1.56. */
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] {
+    padding: 0.58rem 0.65rem 0.35rem;
+}
+
+/* Markdown readability inside assistant cards. */
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h1,
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h2,
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h3,
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h4 {
+    color: #1b2946;
+    letter-spacing: -0.01em;
+}
+
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] code {
+    background: #edf1fb;
+    border-radius: 6px;
+    padding: 0.1rem 0.3rem;
+}
+
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] pre code {
+    display: block;
+    border: 1px solid #dde4f4;
+    background: #f8faff;
+    padding: 0.8rem;
+}
+
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] blockquote {
+    border-left: 3px solid #c4cdfb;
+    margin-left: 0;
+    padding-left: 0.75rem;
+    color: #455574;
+}
+
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] img {
+    border-radius: 10px;
+    border: 1px solid #dce2ef;
+}
+
+/* Uploaded attachment cards rendered from render_content. */
+.attachment-card {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    border: 1px solid #d9e1f3;
+    background: #fbfcff;
+    border-radius: 12px;
+    padding: 0.55rem 0.75rem;
+    margin: 0.15rem 0 0.45rem;
+    max-width: min(92%, 760px);
+}
+
+.attachment-icon {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 10px;
+    background: #edf1ff;
+    display: grid;
+    place-items: center;
+    font-size: 1rem;
+}
+
+.attachment-copy {
+    min-width: 0;
+}
+
+.attachment-name {
+    color: #1f2d4a;
+    font-weight: 700;
+    line-height: 1.2;
+    word-break: break-word;
+}
+
+.attachment-meta {
+    color: #647391;
+    font-size: 0.86rem;
+    font-weight: 500;
 }
 
 /* Streamlit internal avatar test IDs in 1.56 chat message widgets. */
@@ -391,9 +493,11 @@ button[title="View fullscreen"] {
 
 [data-testid="stChatInput"] > div {
     border: 1px solid var(--color-border) !important;
-    border-radius: 16px !important;
+    border-radius: 18px !important;
     background: #ffffff !important;
-    box-shadow: 0 3px 14px rgba(41, 56, 91, 0.08);
+    box-shadow: 0 5px 16px rgba(41, 56, 91, 0.1);
+    padding-top: 0.05rem;
+    padding-bottom: 0.05rem;
 }
 
 [data-testid="stChatInput"] > div:focus-within {


### PR DESCRIPTION
### Motivation
- Make uploaded files in chat more discoverable by rendering a compact attachment badge with filename and size. 
- Preserve existing image display while surfacing metadata for both images and documents. 
- Polish chat message visuals and spacing to improve readability and alignment across user/assistant messages.

### Description
- Added a file-size formatter ` _format_file_size` and a renderer `_render_attachment_badge` inside `render_content` to emit an attachment card with icon, filename, and human-friendly size. 
- Updated `render_content` to show the attachment badge when a content part includes an `_attachment` metadata dictionary. 
- When assembling `parts` from uploaded files, attach `_attachment` metadata for image and document uploads and include `size` on image parts. 
- Expanded `theme.css` with multiple UI refinements including adjusted border radii, shadows, spacing, user/assistant content wrappers, improved markdown/code/blockquote styles, and new styles for the `.attachment-card`, `.attachment-icon`, `.attachment-name`, and `.attachment-meta` elements. 
- Minor layout tweaks to the chat input styling and avatar colors to better match the updated chat bubbles.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe2a8438083288d51d20d2985e0ad)