### PR TITLE
Pin Streamlit 1.56, add UI validation checklist and static UI contract tests, README/typing tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EphemerAl: A Simple Self-Hosted Chat Interface for Local AI with Ollama that Accepts Documents and Images
+# EphemerAl (EphemerAI UI): A Simple Self-Hosted Chat Interface for Local AI with Ollama that Accepts Documents and Images
 
-EphemerAl is a lightweight, open-source web interface for interacting with local LLMs on your hardware via Ollama. I designed it for my day job to help keep our team's sensitive info off cloud services, and to provide a modern AI experience to staff without the per-user cost required to achieve equivalent capabilities online. The repository now targets Qwen3.6-35B-A3B through a stable local alias (`ephemeral-default`) that you create from `qwen3.6:35b-a3b`, and can still be retargeted to other models by changing one environment variable (`LLM_MODEL_NAME`).
+EphemerAl is a lightweight, open-source web interface (user-facing brand: **EphemerAI**) for interacting with local LLMs on your hardware via Ollama. I designed it for my day job to help keep our team's sensitive info off cloud services, and to provide a modern AI experience to staff without the per-user cost required to achieve equivalent capabilities online. The repository now targets Qwen3.6-35B-A3B through a stable local alias (`ephemeral-default`) that you create from `qwen3.6:35b-a3b`, and can still be retargeted to other models by changing one environment variable (`LLM_MODEL_NAME`).
 
 While it wasn't built for broad distribution, I'm sharing this generalized version in case it helps others looking for a local-only, account-free, multimodal LLM interface. . . whether to provide an operational tool, a staff learning environment, or bragging rights when friends visit on your home network.
 
@@ -67,7 +67,7 @@ EphemerAl is designed for trusted local networks (home, office LAN) and does not
 
 ## Technical Stack
 
-- Python 3.11 + Streamlit
+- Python 3.11 + Streamlit 1.56.0
 - Ollama API (OpenAI-compatible endpoint for chat)
 - Apache Tika server
 - Docker Compose (for the included deployment path)
@@ -120,6 +120,21 @@ If your current stack still points at any older model tag, recreate or update yo
 
 - Local: `http://localhost:8501`
 - Network: `http://<host-ip>:8501`
+
+## UI Validation Checklist (Streamlit 1.56)
+
+After deployment (or after UI updates), run this quick manual checklist in a browser:
+
+1. Open the app and confirm the empty welcome screen renders before any chat messages.
+2. Send a text-only prompt and confirm normal response streaming.
+3. Upload a supported document (for example, PDF or DOCX) and confirm document chat still works.
+4. Upload an image and confirm behavior is model-aware:
+   - If the selected model supports vision, the image is accepted and included.
+   - If the selected model does not support vision, the UI shows a clear warning and continues text chat.
+5. Click **New chat** and confirm prior messages/attachments are cleared from the current session.
+6. After at least one exchanged message, click **Copy conversation** and confirm clipboard copy works.
+7. Temporarily stop Ollama or Tika and confirm the app UI still renders with backend-unavailable guidance.
+8. Narrow the browser window (or test on mobile) and confirm basic sidebar/chat usability.
 
 ## Stopping the Application
 

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -7,7 +7,7 @@ import logging
 import inspect
 from datetime import datetime, tzinfo
 from html import escape as html_escape
-from typing import Union, Tuple, List, Dict, Optional
+from typing import Union, List
 
 import streamlit as st
 import pytz

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_requirements_pin_streamlit_156():
+    requirements_text = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
+    assert "streamlit==1.56.0" in requirements_text
+
+
+def test_theme_css_keeps_root_and_chat_role_selectors():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert ":root {" in css
+    assert '[class*="st-key-user-"]' in css
+    assert '[class*="st-key-assistant-"]' in css
+
+
+def test_theme_css_has_no_external_font_or_cdn_imports():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8").lower()
+    forbidden_patterns = [
+        "@import url(",
+        "fonts.googleapis.com",
+        "fonts.gstatic.com",
+        "cdnjs.cloudflare.com",
+        "cdn.jsdelivr.net",
+    ]
+    for pattern in forbidden_patterns:
+        assert pattern not in css
+
+
+def test_streamlit_156_api_cleanup_contracts():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert "streamlit.components.v1" not in app_text
+    assert "use_container_width=" not in app_text
+
+
+def test_docker_service_name_defaults_are_preserved():
+    config_text = (REPO_ROOT / "ephemeral/config.py").read_text(encoding="utf-8")
+    assert 'LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")' in config_text
+    assert 'TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")' in config_text


### PR DESCRIPTION
### Motivation

- Clarify UI branding and developer guidance in the `README.md` and add a short validation checklist targeted at Streamlit `1.56.0` to make manual UI checks reproducible. 
- Provide automated static checks to catch regressions in UI-related files and configuration (Streamlit pin, theme CSS, and service default URLs).
- Remove unused typing imports from `ephemeral_app.py` to keep imports minimal.

### Description

- Update `README.md` wording and title to include the user-facing brand `EphemerAI`, add a `UI Validation Checklist` for Streamlit `1.56`, and explicitly pin Streamlit in the tech stack line to `1.56.0`.
- Simplify typing imports in `ephemeral_app.py` by removing unused names (`Tuple`, `Dict`, `Optional`) while keeping `List` and `Union`.
- Add a new test module `tests/test_ui_static_contracts.py` that enforces: `streamlit==1.56.0` in `requirements.txt`, presence and safeness of selectors in `theme.css`, absence of external font/CDN imports in `theme.css`, Streamlit API cleanup patterns in `ephemeral_app.py`, and default Ollama/Tika service URL entries in `ephemeral/config.py`.

### Testing

- Ran the new test file with `pytest tests/test_ui_static_contracts.py` and all assertions in the file passed. 
- No other automated test failures were observed when validating the static-contract tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfe970a908328b5615fa4856ee93b)