### PR TITLE
Fix Streamlit iframe crash and remove sidebar/welcome placeholders

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -287,7 +287,7 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
         </script>
         """
     iframe_src = "data:text/html;base64," + base64.b64encode(iframe_html.encode("utf-8")).decode("ascii")
-    st.iframe(iframe_src, height=70, width="stretch", scrolling=False)
+    st.iframe(iframe_src, height=70, width="stretch")
 
 
 # ── Session state ─────────────────────────────────────────────────
@@ -374,25 +374,6 @@ with st.sidebar:
             else:
                 st.caption("Token counting: not checked yet")
 
-    st.markdown('<div class="sidebar-footer-spacer"></div>', unsafe_allow_html=True)
-    sidebar_footer = st.container(key="sidebar_footer")
-    with sidebar_footer:
-        if st.button(
-            "⚙ Settings",
-            key="sidebar_settings",
-            width="stretch",
-            help="Opens a safe placeholder message.",
-        ):
-            st.info("Settings UI is coming soon. Core chat privacy and model behavior are unchanged.")
-        if st.button(
-            "❔ Help",
-            key="sidebar_help",
-            width="stretch",
-            help="Opens a safe placeholder message.",
-        ):
-            st.info("Help is coming soon. You can start a new chat any time to clear this conversation.")
-
-
 # ── Welcome banner ────────────────────────────────────────────────
 if st.session_state.show_welcome:
     st.markdown(
@@ -426,22 +407,6 @@ if st.session_state.show_welcome:
             </div>
           </div>
 
-          <div class="welcome-skeletons" aria-hidden="true">
-            <div class="skeleton-card">
-              <div class="skeleton-avatar"></div>
-              <div class="skeleton-lines">
-                <div class="skeleton-line skeleton-line-lg"></div>
-                <div class="skeleton-line skeleton-line-md"></div>
-              </div>
-            </div>
-            <div class="skeleton-card">
-              <div class="skeleton-avatar skeleton-avatar-secondary"></div>
-              <div class="skeleton-lines">
-                <div class="skeleton-line skeleton-line-xl"></div>
-                <div class="skeleton-line skeleton-line-sm"></div>
-              </div>
-            </div>
-          </div>
         </section>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
### Motivation
- Remove an unsupported `st.iframe(...)` argument that caused a runtime crash on first prompt submission. 
- Remove temporary/placeholder UI elements (sidebar Settings/Help and welcome skeleton cards) that were not intended to appear on the landing page. 

### Description
- Removed the unsupported `scrolling` keyword from the `st.iframe(...)` call in `render_copy_button`, preventing the `TypeError` from Streamlit's `IframeMixin.iframe()` implementation. 
- Deleted the sidebar footer block that added the placeholder `⚙ Settings` and `❔ Help` buttons so only the primary sidebar actions remain. 
- Removed the decorative welcome skeleton HTML block from the landing page markup so the welcome view no longer renders the extra ghost cards. 
- All changes were made in `ephemeral_app.py` and preserved existing debug/status behavior. 

### Testing
- Ran syntax check with `python -m py_compile ephemeral_app.py ephemeral/*.py`, which completed successfully. 
- Ran the test suite with `python -m pytest -q`, which returned `21 passed` and exit code 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec042b34a4832890dd1ff00bee75f3)