### PR TITLE
Adapt chat wrapper and theme for Streamlit 1.56 UI changes

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -5,6 +5,7 @@ import string
 import uuid
 import logging
 import inspect
+from contextlib import contextmanager
 from datetime import datetime, tzinfo
 from html import escape as html_escape
 from typing import Union, List
@@ -135,16 +136,29 @@ else:
 
 
 # ── Chat message wrapper for CSS styling ──────────────────────────
+@contextmanager
 def styled_chat_message(role: str, message_id: str = None):
-    """Return a chat_message wrapped in a keyed container for CSS styling."""
+    """Yield a chat_message wrapped in keyed containers for stable role CSS hooks."""
     normalized_role = "user" if role == "user" else "assistant"
     key = f"{normalized_role}-{message_id}" if message_id else f"{normalized_role}-{uuid.uuid4()}"
     chat_kwargs = {
         "avatar": ":material/person:" if normalized_role == "user" else ":material/auto_awesome:",
     }
     if "width" in inspect.signature(st.chat_message).parameters:
-        chat_kwargs["width"] = "stretch"
-    return st.container(key=key).chat_message(normalized_role, **chat_kwargs)
+        chat_kwargs["width"] = "content" if normalized_role == "user" else "stretch"
+
+    with st.container(key=key):
+        if normalized_role == "user":
+            if "horizontal_alignment" in inspect.signature(st.container).parameters:
+                with st.container(horizontal_alignment="right"):
+                    with st.chat_message(normalized_role, **chat_kwargs):
+                        yield
+            else:
+                with st.chat_message(normalized_role, **chat_kwargs):
+                    yield
+        else:
+            with st.chat_message(normalized_role, **chat_kwargs):
+                yield
 
 
 def render_copy_button(export_text_plain: str, export_html: str) -> None:

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -16,6 +16,26 @@ def test_theme_css_keeps_root_and_chat_role_selectors():
     assert '[class*="st-key-assistant-"]' in css
 
 
+def test_theme_css_has_streamlit_156_chat_input_contract_selectors():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert '[data-testid="stChatInput"]' in css
+    assert '[data-testid="stChatInputTextArea"]' in css
+    assert '[data-testid="stChatInputSubmitButton"]' in css
+
+
+def test_theme_css_supports_sidebar_new_key_variants():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert '[class*="st-key-sidebar_new"] .stButton > button' in css
+    assert '[class*="st-key-sidebar-new"] .stButton > button' in css
+
+
+def test_theme_css_keeps_compact_right_aligned_user_message_contract():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert '[class*="st-key-user-"] [data-testid="stChatMessage"]' in css
+    assert "margin-left: auto;" in css
+    assert "width: fit-content;" in css
+
+
 def test_theme_css_has_no_external_font_or_cdn_imports():
     css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8").lower()
     forbidden_patterns = [

--- a/theme.css
+++ b/theme.css
@@ -173,15 +173,17 @@ button[title="View fullscreen"] {
     background: transparent;
 }
 
-/* Streamlit internal class fragment: key-based style for primary New chat button. */
-[class*="st-key-sidebar_new"] .stButton > button {
+/* Streamlit internal class fragment in 1.56: key-based style for primary New chat button. */
+[class*="st-key-sidebar_new"] .stButton > button,
+[class*="st-key-sidebar-new"] .stButton > button {
     background: var(--color-accent);
     border-color: var(--color-accent);
     color: #ffffff;
     box-shadow: 0 8px 16px rgba(79, 91, 234, 0.3);
 }
 
-[class*="st-key-sidebar_new"] .stButton > button:hover {
+[class*="st-key-sidebar_new"] .stButton > button:hover,
+[class*="st-key-sidebar-new"] .stButton > button:hover {
     background: var(--color-accent-strong);
     border-color: var(--color-accent-strong);
 }
@@ -356,7 +358,7 @@ button[title="View fullscreen"] {
 /* Streamlit internal test IDs for chat blocks in 1.56. */
 [data-testid="stChatMessage"] {
     border-radius: 16px;
-    padding: 0.12rem 0.2rem;
+    padding: 0.08rem 0.2rem;
     border: 1px solid var(--color-border);
     box-shadow: 0 4px 14px rgba(24, 35, 65, 0.05);
     margin-bottom: 0.35rem;
@@ -364,16 +366,20 @@ button[title="View fullscreen"] {
 
 /* Preserve role wrapper architecture from st-key-{role}- containers. */
 [class*="st-key-user-"] [data-testid="stChatMessage"] {
-    background: var(--color-user-msg-bg) !important;
-    border: 1px solid #d8defb !important;
-    border-radius: 16px !important;
-    box-shadow: 0 4px 14px rgba(68, 84, 170, 0.08) !important;
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+    width: fit-content;
+    max-width: min(78ch, 86%);
+    margin-left: auto;
+    margin-right: 0;
 }
 
 /* Streamlit internal structure: user row wrapper to emulate right aligned bubbles + avatar. */
 [class*="st-key-user-"] [data-testid="stChatMessage"] > div {
     flex-direction: row-reverse;
     justify-content: flex-start;
+    align-items: flex-end;
     gap: 0.65rem;
 }
 
@@ -381,11 +387,13 @@ button[title="View fullscreen"] {
 [class*="st-key-user-"] [data-testid="stChatMessageContent"] {
     margin-left: auto;
     text-align: left;
-    background: linear-gradient(180deg, #f0f3ff 0%, #e9eeff 100%);
-    border-radius: 16px;
-    border: 1px solid #d7defe;
-    padding: 0.72rem 0.9rem;
-    max-width: min(86%, 760px);
+    background: linear-gradient(180deg, #f2f4ff 0%, #ebefff 100%);
+    border-radius: 16px 16px 6px 16px;
+    border: 1px solid #d8defe;
+    box-shadow: 0 2px 8px rgba(74, 91, 176, 0.08);
+    padding: 0.62rem 0.86rem;
+    width: fit-content;
+    max-width: min(72ch, 100%);
 }
 
 [class*="st-key-assistant-"] [data-testid="stChatMessage"] {
@@ -432,6 +440,19 @@ button[title="View fullscreen"] {
 [class*="st-key-assistant-"] [data-testid="stChatMessageContent"] img {
     border-radius: 10px;
     border: 1px solid #dce2ef;
+}
+
+/* Keep user attachments visually compact and inside the bubble flow. */
+[class*="st-key-user-"] .attachment-card {
+    max-width: min(64ch, 100%);
+    margin-left: 0;
+    margin-right: 0;
+}
+
+/* Streamlit 1.56 internals: st.image wrapper inside user chat bubbles. */
+[class*="st-key-user-"] [data-testid="stImage"] img {
+    max-width: min(320px, 100%);
+    border-radius: 10px;
 }
 
 /* Uploaded attachment cards rendered from render_content. */
@@ -491,18 +512,78 @@ button[title="View fullscreen"] {
     background: var(--color-bg-main) !important;
 }
 
+/* Streamlit 1.56 internals: unified chat input root surface. */
 [data-testid="stChatInput"] > div {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     border: 1px solid var(--color-border) !important;
     border-radius: 18px !important;
     background: #ffffff !important;
     box-shadow: 0 5px 16px rgba(41, 56, 91, 0.1);
-    padding-top: 0.05rem;
-    padding-bottom: 0.05rem;
+    padding: 0.3rem 0.42rem !important;
 }
 
 [data-testid="stChatInput"] > div:focus-within {
     border-color: var(--color-accent) !important;
     box-shadow: 0 0 0 1px var(--color-accent) !important;
+}
+
+/* Streamlit 1.56 internals: textarea wrapper + textarea should stay transparent. */
+[data-testid="stChatInputTextArea"],
+[data-testid="stChatInputTextArea"] > div,
+[data-testid="stChatInputTextArea"] textarea {
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+}
+
+[data-testid="stChatInputTextArea"] {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+[data-testid="stChatInput"] textarea {
+    padding: 0.35rem 0.2rem !important;
+}
+
+/* Streamlit 1.56 internals: upload control in chat input left rail. */
+/* Uses localized aria-label fragments exposed by Streamlit's native file-enabled chat_input. */
+[data-testid="stChatInput"] button[kind="secondary"][aria-label*="Attach"],
+[data-testid="stChatInput"] button[kind="secondary"][aria-label*="Upload"] {
+    width: 2.15rem;
+    height: 2.15rem;
+    border-radius: 10px;
+    border: 1px solid #dbe2f2;
+    background: #f7f9ff;
+    padding: 0;
+}
+
+/* Streamlit 1.56 internals: submit button container + button styling. */
+[data-testid="stChatInputSubmitButton"] {
+    margin-left: auto;
+}
+
+[data-testid="stChatInputSubmitButton"] button {
+    min-width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 10px;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 4px 10px rgba(79, 91, 234, 0.28);
+}
+
+[data-testid="stChatInputSubmitButton"] button:hover:enabled {
+    background: var(--color-accent-strong);
+    border-color: var(--color-accent-strong);
+}
+
+[data-testid="stChatInputSubmitButton"] button:disabled {
+    border-color: #d0d7e8;
+    background: #e9edf5;
+    color: #8a96ad;
+    box-shadow: none;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- Update the chat rendering and CSS to be compatible with Streamlit 1.56 internal structure and test IDs.
- Ensure user messages remain compact and right-aligned while preserving assistant styling and attachments.
- Stabilize sidebar "New chat" button styling across small key-name variants introduced by Streamlit.

### Description
- Modify `styled_chat_message` in `ephemeral_app.py` to be a `@contextmanager`, yield a keyed container, use `width` hints differently for user vs assistant, and optionally nest a right-aligned container when `horizontal_alignment` is supported.  
- Revise `theme.css` to add Streamlit 1.56 test-ID selectors (`stChatInput`, `stChatInputTextArea`, `stChatInputSubmitButton`, `stChatMessage`, etc.), support both `st-key-sidebar_new` and `st-key-sidebar-new` variants, tighten paddings and bubble shapes for user messages, size attachments and images inside user bubbles, and style the unified chat input and submit controls.  
- Extend `tests/test_ui_static_contracts.py` with assertions that verify the new CSS selectors and sidebar key variants are present and that user-message layout contracts are preserved.

### Testing
- Ran the UI static contract tests with `pytest tests/test_ui_static_contracts.py`, and all new and existing assertions passed.  
- Ran the repository test suite (`pytest`) and reported no failures in the modified areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2bc00cc8832892d5cd018e917bae)