### PR TITLE
Improve chat message container handling and update theme for Streamlit 1.56

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -5,6 +5,7 @@ import string
 import uuid
 import logging
 import inspect
+from contextlib import contextmanager
 from datetime import datetime, tzinfo
 from html import escape as html_escape
 from typing import Union, List
@@ -135,16 +136,29 @@ else:
 
 
 # ── Chat message wrapper for CSS styling ──────────────────────────
+@contextmanager
 def styled_chat_message(role: str, message_id: str = None):
-    """Return a chat_message wrapped in a keyed container for CSS styling."""
+    """Yield a chat_message wrapped in keyed containers for stable role CSS hooks."""
     normalized_role = "user" if role == "user" else "assistant"
     key = f"{normalized_role}-{message_id}" if message_id else f"{normalized_role}-{uuid.uuid4()}"
     chat_kwargs = {
         "avatar": ":material/person:" if normalized_role == "user" else ":material/auto_awesome:",
     }
     if "width" in inspect.signature(st.chat_message).parameters:
-        chat_kwargs["width"] = "stretch"
-    return st.container(key=key).chat_message(normalized_role, **chat_kwargs)
+        chat_kwargs["width"] = "content" if normalized_role == "user" else "stretch"
+
+    with st.container(key=key):
+        if normalized_role == "user":
+            if "horizontal_alignment" in inspect.signature(st.container).parameters:
+                with st.container(horizontal_alignment="right"):
+                    with st.chat_message(normalized_role, **chat_kwargs):
+                        yield
+            else:
+                with st.chat_message(normalized_role, **chat_kwargs):
+                    yield
+        else:
+            with st.chat_message(normalized_role, **chat_kwargs):
+                yield
 
 
 def render_copy_button(export_text_plain: str, export_html: str) -> None:

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -13,7 +13,29 @@ def test_theme_css_keeps_root_and_chat_role_selectors():
     css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
     assert ":root {" in css
     assert '[class*="st-key-user-"]' in css
+    assert '[class*="st-key-user_"]' in css
     assert '[class*="st-key-assistant-"]' in css
+    assert '[class*="st-key-assistant_"]' in css
+
+
+def test_theme_css_has_streamlit_156_chat_input_contract_selectors():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert '[data-testid="stChatInput"]' in css
+    assert '[data-testid="stChatInputTextArea"]' in css
+    assert '[data-testid="stChatInputSubmitButton"]' in css
+
+
+def test_theme_css_supports_sidebar_new_key_variants():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert '[class*="st-key-sidebar_new"] .stButton > button' in css
+    assert '[class*="st-key-sidebar-new"] .stButton > button' in css
+
+
+def test_theme_css_keeps_compact_right_aligned_user_message_contract():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert '[class*="st-key-user-"] [data-testid="stChatMessage"]' in css
+    assert "margin-left: auto;" in css
+    assert "width: fit-content;" in css
 
 
 def test_theme_css_has_no_external_font_or_cdn_imports():

--- a/theme.css
+++ b/theme.css
@@ -173,15 +173,17 @@ button[title="View fullscreen"] {
     background: transparent;
 }
 
-/* Streamlit internal class fragment: key-based style for primary New chat button. */
-[class*="st-key-sidebar_new"] .stButton > button {
+/* Streamlit internal class fragment in 1.56: key-based style for primary New chat button. */
+[class*="st-key-sidebar_new"] .stButton > button,
+[class*="st-key-sidebar-new"] .stButton > button {
     background: var(--color-accent);
     border-color: var(--color-accent);
     color: #ffffff;
     box-shadow: 0 8px 16px rgba(79, 91, 234, 0.3);
 }
 
-[class*="st-key-sidebar_new"] .stButton > button:hover {
+[class*="st-key-sidebar_new"] .stButton > button:hover,
+[class*="st-key-sidebar-new"] .stButton > button:hover {
     background: var(--color-accent-strong);
     border-color: var(--color-accent-strong);
 }
@@ -356,39 +358,53 @@ button[title="View fullscreen"] {
 /* Streamlit internal test IDs for chat blocks in 1.56. */
 [data-testid="stChatMessage"] {
     border-radius: 16px;
-    padding: 0.12rem 0.2rem;
+    padding: 0.08rem 0.2rem;
     border: 1px solid var(--color-border);
     box-shadow: 0 4px 14px rgba(24, 35, 65, 0.05);
     margin-bottom: 0.35rem;
 }
 
-/* Preserve role wrapper architecture from st-key-{role}- containers. */
-[class*="st-key-user-"] [data-testid="stChatMessage"] {
-    background: var(--color-user-msg-bg) !important;
-    border: 1px solid #d8defb !important;
-    border-radius: 16px !important;
-    box-shadow: 0 4px 14px rgba(68, 84, 170, 0.08) !important;
+/* Preserve role wrapper architecture from st-key-{role}- containers.
+   Streamlit may sanitize key separators as "-" or "_" depending on context. */
+[class*="st-key-user-"] [data-testid="stChatMessage"],
+[class*="st-key-user_"] [data-testid="stChatMessage"] {
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+    width: 100%;
+    max-width: 100%;
+    margin: 0 0 0.35rem 0;
 }
 
 /* Streamlit internal structure: user row wrapper to emulate right aligned bubbles + avatar. */
-[class*="st-key-user-"] [data-testid="stChatMessage"] > div {
+[class*="st-key-user-"] [data-testid="stChatMessage"] > div,
+[class*="st-key-user_"] [data-testid="stChatMessage"] > div {
     flex-direction: row-reverse;
     justify-content: flex-start;
+    align-items: flex-end;
     gap: 0.65rem;
+    width: fit-content;
+    max-width: min(78ch, 86%);
+    margin-left: auto;
 }
 
 /* Streamlit internal test ID: content wrapper inside chat message in 1.56. */
-[class*="st-key-user-"] [data-testid="stChatMessageContent"] {
+[class*="st-key-user-"] [data-testid="stChatMessageContent"],
+[class*="st-key-user_"] [data-testid="stChatMessageContent"] {
     margin-left: auto;
     text-align: left;
-    background: linear-gradient(180deg, #f0f3ff 0%, #e9eeff 100%);
-    border-radius: 16px;
-    border: 1px solid #d7defe;
-    padding: 0.72rem 0.9rem;
-    max-width: min(86%, 760px);
+    background: linear-gradient(180deg, #f2f4ff 0%, #ebefff 100%);
+    border-radius: 16px 16px 6px 16px;
+    border: 1px solid #d8defe;
+    box-shadow: 0 2px 8px rgba(74, 91, 176, 0.08);
+    padding: 0.62rem 0.86rem;
+    width: fit-content;
+    max-width: min(72ch, 100%);
+    display: inline-block;
 }
 
-[class*="st-key-assistant-"] [data-testid="stChatMessage"] {
+[class*="st-key-assistant-"] [data-testid="stChatMessage"],
+[class*="st-key-assistant_"] [data-testid="stChatMessage"] {
     background: var(--color-asst-msg-bg) !important;
     border: 1px solid #dbe1ef !important;
     border-left: 4px solid var(--color-asst-msg-border) !important;
@@ -396,42 +412,66 @@ button[title="View fullscreen"] {
 }
 
 /* Streamlit internal test ID: content wrapper inside chat message in 1.56. */
-[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] {
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"],
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] {
     padding: 0.58rem 0.65rem 0.35rem;
 }
 
 /* Markdown readability inside assistant cards. */
 [class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h1,
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] h1,
 [class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h2,
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] h2,
 [class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h3,
-[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h4 {
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] h3,
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] h4,
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] h4 {
     color: #1b2946;
     letter-spacing: -0.01em;
 }
 
-[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] code {
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] code,
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] code {
     background: #edf1fb;
     border-radius: 6px;
     padding: 0.1rem 0.3rem;
 }
 
-[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] pre code {
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] pre code,
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] pre code {
     display: block;
     border: 1px solid #dde4f4;
     background: #f8faff;
     padding: 0.8rem;
 }
 
-[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] blockquote {
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] blockquote,
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] blockquote {
     border-left: 3px solid #c4cdfb;
     margin-left: 0;
     padding-left: 0.75rem;
     color: #455574;
 }
 
-[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] img {
+[class*="st-key-assistant-"] [data-testid="stChatMessageContent"] img,
+[class*="st-key-assistant_"] [data-testid="stChatMessageContent"] img {
     border-radius: 10px;
     border: 1px solid #dce2ef;
+}
+
+/* Keep user attachments visually compact and inside the bubble flow. */
+[class*="st-key-user-"] .attachment-card,
+[class*="st-key-user_"] .attachment-card {
+    max-width: min(64ch, 100%);
+    margin-left: 0;
+    margin-right: 0;
+}
+
+/* Streamlit 1.56 internals: st.image wrapper inside user chat bubbles. */
+[class*="st-key-user-"] [data-testid="stImage"] img,
+[class*="st-key-user_"] [data-testid="stImage"] img {
+    max-width: min(320px, 100%);
+    border-radius: 10px;
 }
 
 /* Uploaded attachment cards rendered from render_content. */
@@ -491,18 +531,90 @@ button[title="View fullscreen"] {
     background: var(--color-bg-main) !important;
 }
 
+/* Streamlit 1.56 internals: unified chat input root surface. */
 [data-testid="stChatInput"] > div {
     border: 1px solid var(--color-border) !important;
     border-radius: 18px !important;
     background: #ffffff !important;
     box-shadow: 0 5px 16px rgba(41, 56, 91, 0.1);
-    padding-top: 0.05rem;
-    padding-bottom: 0.05rem;
+    padding: 0.3rem 0.42rem !important;
 }
 
 [data-testid="stChatInput"] > div:focus-within {
     border-color: var(--color-accent) !important;
     box-shadow: 0 0 0 1px var(--color-accent) !important;
+}
+
+/* Streamlit 1.56 internals: normalize chat input row layout to prevent wrapped controls. */
+[data-testid="stChatInput"] form,
+[data-testid="stChatInput"] form > div {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    width: 100%;
+}
+
+/* Streamlit 1.56 internals: textarea wrapper + textarea should stay transparent. */
+[data-testid="stChatInputTextArea"],
+[data-testid="stChatInputTextArea"] > div,
+[data-testid="stChatInputTextArea"] textarea {
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+}
+
+[data-testid="stChatInputTextArea"] {
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+[data-testid="stChatInputTextArea"] > div {
+    width: 100%;
+}
+
+[data-testid="stChatInput"] textarea {
+    padding: 0.35rem 0.2rem !important;
+}
+
+/* Streamlit 1.56 internals: upload control in chat input left rail. */
+/* Uses localized aria-label fragments exposed by Streamlit's native file-enabled chat_input. */
+[data-testid="stChatInput"] button[kind="secondary"][aria-label*="Attach"],
+[data-testid="stChatInput"] button[kind="secondary"][aria-label*="Upload"] {
+    width: 2.15rem;
+    height: 2.15rem;
+    border-radius: 10px;
+    border: 1px solid #dbe2f2;
+    background: #f7f9ff;
+    padding: 0;
+    flex: 0 0 auto;
+}
+
+/* Streamlit 1.56 internals: submit button container + button styling. */
+[data-testid="stChatInputSubmitButton"] {
+    margin-left: auto;
+}
+
+[data-testid="stChatInputSubmitButton"] button {
+    min-width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 10px;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 4px 10px rgba(79, 91, 234, 0.28);
+}
+
+[data-testid="stChatInputSubmitButton"] button:hover:enabled {
+    background: var(--color-accent-strong);
+    border-color: var(--color-accent-strong);
+}
+
+[data-testid="stChatInputSubmitButton"] button:disabled {
+    border-color: #d0d7e8;
+    background: #e9edf5;
+    color: #8a96ad;
+    box-shadow: none;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation

- Provide a stable, yield-based wrapper for rendering chat messages so role-based CSS hooks are consistent and right-aligned user messages behave correctly across Streamlit versions. 
- Update theme rules to handle Streamlit 1.56 internal class/test-id changes and multiple key separator variants so the UI remains visually correct. 
- Add static contract tests to assert the new CSS selectors and input/chat widget contracts exist.

### Description

- Convert `styled_chat_message` into a `@contextmanager` that yields inside keyed `st.container` and `st.chat_message`, normalizes roles, and uses `horizontal_alignment` when available to right-align user messages. 
- Adjust `chat_kwargs` width mapping to `content` for user messages and `stretch` for assistant messages when supported. 
- Import `contextmanager` from `contextlib`. 
- Extend `theme.css` with many updates: support both `st-key-...-` and `st-key_...` key separators, add selectors and layout rules for Streamlit 1.56 chat input test IDs (`stChatInput`, `stChatInputTextArea`, `stChatInputSubmitButton`), improve user/assistant bubble layout, padding, attachments and image sizing, and sidebar-new-button key variants. 
- Update `tests/test_ui_static_contracts.py` to assert the new and adjusted CSS selectors and Streamlit 1.56 contract selectors.

### Testing

- Ran the static UI contract tests in `tests/test_ui_static_contracts.py` under `pytest`, and all assertions in the modified test file passed. 
- No additional automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2bc00cc8832892d5cd018e917bae)