### PR TITLE
Refresh welcome copy and UI labels; adjust welcome layout and styles

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -336,7 +336,7 @@ with st.sidebar:
     if not tika_alive():
         st.info("Document reading is temporarily unavailable. You can still chat, but uploads may not be readable.")
 
-    if st.button("New Conversation", key="sidebar_new", width="stretch"):
+    if st.button("New Chat", key="sidebar_new", width="stretch"):
         st.session_state.clear()
         st.rerun()
 
@@ -391,24 +391,24 @@ if st.session_state.show_welcome:
           <div class="welcome-card">
             <div class="welcome-features" role="list">
               <div class="welcome-feature" role="listitem">
-                <div class="feature-badge feature-badge-blue">📄</div>
+                <div class="feature-badge feature-badge-blue">+</div>
                 <div class="feature-copy">
-                  <div class="feature-copy-strong">I can read many document types, and sometimes images</div>
-                  <div class="feature-copy-muted">depending on the model.</div>
+                  <div class="feature-copy-strong">Attach files, not just prompts</div>
+                  <div class="feature-copy-muted">PDFs, Office files, spreadsheets, text, and more. Images work when the model supports them.</div>
                 </div>
               </div>
               <div class="welcome-feature" role="listitem">
-                <div class="feature-badge feature-badge-indigo">🛡</div>
+                <div class="feature-badge feature-badge-indigo">↺</div>
                 <div class="feature-copy">
-                  <div class="feature-copy-strong">Conversations are cleared when you start a new chat</div>
-                  <div class="feature-copy-muted">or close your browser.</div>
+                  <div class="feature-copy-strong">Local and session-only</div>
+                  <div class="feature-copy-muted">No account or saved chat history in this app. New Chat clears messages and uploads.</div>
                 </div>
               </div>
               <div class="welcome-feature" role="listitem">
-                <div class="feature-badge feature-badge-green">✓</div>
+                <div class="feature-badge feature-badge-amber">!</div>
                 <div class="feature-copy">
-                  <div class="feature-copy-strong">I try to be helpful, but I can be wrong.</div>
-                  <div class="feature-copy-muted">Please double-check important answers.</div>
+                  <div class="feature-copy-strong">Verify important answers</div>
+                  <div class="feature-copy-muted">This local model has no live web access and may be wrong, especially on current facts.</div>
                 </div>
               </div>
             </div>
@@ -492,14 +492,14 @@ for m in st.session_state.messages:
 
 # ── Mobile convenience button ─────────────────────────────────────
 if HAS_DEVICE_DETECTION and device and device.is_mobile:
-    if st.button("🔄 New Conversation", key="mobile_new", width="stretch"):
+    if st.button("🔄 New Chat", key="mobile_new", width="stretch"):
         st.session_state.clear()
         st.rerun()
 
 
 # ── Chat input ───────────────────────────────────────────────────
 prompt_in = st.chat_input(
-    "Ask me anything...",
+    "Ask a question or attach files...",
     accept_file="multiple",
     max_upload_size=50,
     key="main_chat",

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -77,6 +77,27 @@ def test_streamlit_156_api_cleanup_contracts():
     assert "use_container_width=" not in app_text
 
 
+def test_welcome_state_copy_contracts():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert "Attach files, not just prompts" in app_text
+    assert "Local and session-only" in app_text
+    assert "Verify important answers" in app_text
+    assert (
+        "PDFs, Office files, spreadsheets, text, and more. Images work when the model supports them." in app_text
+    )
+    assert "No account or saved chat history in this app. New Chat clears messages and uploads." in app_text
+    assert (
+        "This local model has no live web access and may be wrong, especially on current facts." in app_text
+    )
+
+
+def test_new_chat_labels_and_placeholder_contracts():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert "Ask a question or attach files..." in app_text
+    assert "New Chat" in app_text
+    assert "🔄 New Chat" in app_text
+
+
 def test_docker_service_name_defaults_are_preserved():
     config_text = (REPO_ROOT / "ephemeral/config.py").read_text(encoding="utf-8")
     assert 'LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")' in config_text

--- a/theme.css
+++ b/theme.css
@@ -173,7 +173,7 @@ button[title="View fullscreen"] {
     background: transparent;
 }
 
-/* Streamlit internal class fragment in 1.56: key-based style for primary New Conversation button. */
+/* Streamlit internal class fragment in 1.56: key-based style for primary New Chat button. */
 [class*="st-key-sidebar_new"] .stButton > button,
 [class*="st-key-sidebar-new"] .stButton > button {
     background: var(--color-accent);
@@ -211,7 +211,7 @@ button[title="View fullscreen"] {
 
 /* Welcome foundation */
 .welcome-shell {
-    max-width: 620px;
+    max-width: 660px;
     margin: 3rem auto 0.7rem;
     padding: 0 0.6rem;
 }
@@ -267,8 +267,9 @@ button[title="View fullscreen"] {
     border-radius: 999px;
     display: grid;
     place-items: center;
-    font-size: 1rem;
+    font-size: 1.02rem;
     font-weight: 700;
+    line-height: 1;
     flex-shrink: 0;
 }
 
@@ -282,21 +283,40 @@ button[title="View fullscreen"] {
     color: #5f67db;
 }
 
-.feature-badge-green {
-    background: #e9f7ef;
-    color: var(--color-success);
+.feature-badge-amber {
+    background: #fff7e9;
+    color: #8c650f;
 }
 
 .feature-copy-strong {
     color: var(--color-text);
     font-size: 1.03rem;
     font-weight: 700;
+    line-height: 1.35;
 }
 
 .feature-copy-muted {
     color: var(--color-text-muted);
     font-size: 0.96rem;
     font-weight: 500;
+    line-height: 1.42;
+    margin-top: 0.18rem;
+}
+
+@media (max-width: 720px) {
+    .welcome-shell {
+        max-width: 620px;
+    }
+
+    .welcome-feature {
+        gap: 0.78rem;
+    }
+
+    .feature-badge {
+        width: 34px;
+        height: 34px;
+        font-size: 0.96rem;
+    }
 }
 
 .welcome-skeletons {


### PR DESCRIPTION
### Motivation
- Clarify onboarding copy to emphasize file uploads and privacy expectations in the welcome panel. 
- Make the primary sidebar/mobile action and chat placeholder more user-focused by switching to a shorter label and highlighting attachments. 
- Improve visual layout and responsiveness of the welcome card for better presentation across viewports.

### Description
- Updated UI copy in `ephemeral_app.py` to replace the sidebar/mobile button label `"New Conversation"` with `"New Chat"` and to change the chat placeholder to `"Ask a question or attach files..."`.
- Refreshed the welcome feature text and badge icons in `ephemeral_app.py` to emphasize file attachments, local/session-only behavior, and a verification disclaimer for model outputs.
- Adjusted welcome layout and typography in `theme.css`, including increasing `.welcome-shell` max width, tuning `.feature-badge` sizing and line-height, swapping the green badge to an amber style, and adding responsive rules for smaller viewports.
- Updated a CSS comment to reference the new `New Chat` primary button key and preserved existing sidebar button styling selectors.

### Testing
- Added unit tests in `tests/test_ui_static_contracts.py` (`test_welcome_state_copy_contracts` and `test_new_chat_labels_and_placeholder_contracts`) that assert the new strings and labels exist in `ephemeral_app.py` and they passed.
- Ran the repository static UI contract tests in `tests/test_ui_static_contracts.py` and they completed successfully.
- Existing CSS and config contract tests were also executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec50ec803c8328a31960978af9b51e)