### PR TITLE
Fix clipboard mojibake and add rich HTML clipboard copy

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -168,6 +168,7 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
     hover_tip = "Copy conversation to clipboard"
 
     iframe_html = f"""
+        <meta charset="utf-8" />
         <style>
           html, body {{
             margin: 0;
@@ -280,8 +281,26 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
             return ok;
           }}
 
-          btn.addEventListener("click", () => {{
-            const richOk = copySelectionFrom(rich);
+          async function copyWithClipboardApi() {{
+            if (!navigator.clipboard || !window.ClipboardItem) {{
+              return false;
+            }}
+
+            try {{
+              const item = new ClipboardItem({{
+                "text/plain": new Blob([plain.value], {{ type: "text/plain;charset=utf-8" }}),
+                "text/html": new Blob([rich.innerHTML], {{ type: "text/html;charset=utf-8" }}),
+              }});
+              await navigator.clipboard.write([item]);
+              return true;
+            }} catch (e) {{
+              return false;
+            }}
+          }}
+
+          btn.addEventListener("click", async () => {{
+            const modernOk = await copyWithClipboardApi();
+            const richOk = modernOk ? true : copySelectionFrom(rich);
             const ok = richOk || copyPlain();
 
             if (ok) {{
@@ -292,7 +311,9 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
           }});
         </script>
         """
-    iframe_src = "data:text/html;base64," + base64.b64encode(iframe_html.encode("utf-8")).decode("ascii")
+    iframe_src = "data:text/html;charset=utf-8;base64," + base64.b64encode(
+        iframe_html.encode("utf-8")
+    ).decode("ascii")
     st.iframe(iframe_src, height=58, width="stretch")
 
 


### PR DESCRIPTION
### Motivation
- Users reported mojibake (`â€“`, `â€”`) and loss of formatting when using the sidebar **Copy conversation** button and pasting into rich editors. 
- The goal is to preserve Unicode punctuation and retain rich formatting when the target supports HTML clipboard types.

### Description
- Added an explicit `<meta charset="utf-8" />` to the iframe HTML to ensure the document is interpreted as UTF‑8. 
- Switched the iframe data URI to include `charset=utf-8` (`data:text/html;charset=utf-8;base64,...`) so pasted en/em dashes do not become mojibake. 
- Implemented a modern clipboard path using `navigator.clipboard.write` + `ClipboardItem` that writes both `text/plain` and `text/html` (UTF‑8) to the clipboard, while retaining the existing `document.execCommand` selection/plain fallbacks. 
- Changes are contained to `ephemeral_app.py` in the `render_copy_button` function and preserve the previous fallback behavior for older environments.

### Testing
- Verified Python syntax with `python -m py_compile ephemeral_app.py ephemeral/*.py` which succeeded. 
- Ran the test suite with `python -m pytest -q` and all tests passed (`26 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec553f2b508328a509ecc8fa56d5c2)