### PR TITLE
Improve rich formatting retention for Copy Conversation

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -269,6 +269,30 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
             return ok;
           }}
 
+          function copyWithExecHtml() {{
+            let copied = false;
+            const onCopy = (event) => {{
+              try {{
+                event.preventDefault();
+                event.clipboardData.setData("text/plain", plain.value);
+                event.clipboardData.setData("text/html", rich.innerHTML);
+                copied = true;
+              }} catch (e) {{
+                copied = false;
+              }}
+            }};
+
+            document.addEventListener("copy", onCopy, {{ once: true }});
+
+            try {{
+              document.execCommand("copy");
+            }} catch (e) {{
+              copied = false;
+            }}
+
+            return copied;
+          }}
+
           function copyPlain() {{
             plain.focus();
             plain.select();
@@ -300,7 +324,8 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
 
           btn.addEventListener("click", async () => {{
             const modernOk = await copyWithClipboardApi();
-            const richOk = modernOk ? true : copySelectionFrom(rich);
+            const eventOk = modernOk ? true : copyWithExecHtml();
+            const richOk = eventOk ? true : copySelectionFrom(rich);
             const ok = richOk || copyPlain();
 
             if (ok) {{


### PR DESCRIPTION
### Motivation
- Paste targets like Google Docs were losing bolding, headers, and lists because the clipboard path sometimes provided only plain text instead of HTML; the change aims to improve fidelity when users copy conversations.
- Provide a stronger fallback that explicitly supplies `text/html` alongside `text/plain` when the modern Clipboard API is unavailable or restricted.

### Description
- Added a new JS helper `copyWithExecHtml` that injects both `text/plain` and `text/html` into `event.clipboardData` via a `copy` event handler and then calls `document.execCommand("copy")`.
- Updated the copy button click flow to try strategies in this order: `copyWithClipboardApi()` → `copyWithExecHtml()` → `copySelectionFrom(rich)` → `copyPlain()`.
- Left existing hidden rich-HTML container and plain-text textarea fallbacks intact and made no changes to backend, persistence, or logging behavior.

### Testing
- Verified Python syntax with `python -m py_compile ephemeral_app.py ephemeral/*.py`, which succeeded.
- Ran the test suite with `python -m pytest -q`, which succeeded (`26 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5be359ac8328b7d12e249e82eb04)