### PR TITLE
Add per-turn rich copy button in chat UI

### DIFF
--- a/ephemeral/export.py
+++ b/ephemeral/export.py
@@ -99,23 +99,7 @@ def build_conversation_markdown(messages: List[dict]) -> str:
     lines: List[str] = ["# EphemerAl Conversation", ""]
 
     for msg in messages:
-        role = msg.get("role", "assistant")
-        role_title = "User" if role == "user" else "Assistant"
-        lines.append(f"**{role_title}**")
-
-        doc_lines, img_lines, message_text = _extract_export_info(msg.get("content", ""))
-
-        if doc_lines or img_lines:
-            lines.append("")
-            lines.append("Attachments:")
-            lines.extend(doc_lines)
-            lines.extend(img_lines)
-
-        if message_text:
-            lines.append("")
-            lines.append(message_text)
-
-        lines.append("")
+        lines.extend(_build_message_markdown_lines(msg))
         lines.append("---")
         lines.append("")
 
@@ -232,24 +216,58 @@ def build_conversation_html(messages: List[dict]) -> str:
     chunks: List[str] = ["<div>", "<p><strong>EphemerAl Conversation</strong></p>"]
 
     for msg in messages:
-        role = msg.get("role", "assistant")
-        role_title = "User" if role == "user" else "Assistant"
-        chunks.append(f"<p><strong>{html_escape(role_title)}</strong></p>")
-
-        doc_lines, img_lines, message_text = _extract_export_info(msg.get("content", ""))
-
-        if doc_lines or img_lines:
-            chunks.append("<p><strong>Attachments:</strong></p>")
-            chunks.append("<ul>")
-            for line in (doc_lines + img_lines):
-                item = line.lstrip("- ").strip()
-                chunks.append("<li>" + _inline_md_to_html(item) + "</li>")
-            chunks.append("</ul>")
-
-        if message_text:
-            chunks.append(_md_to_html_basic(message_text))
-
+        chunks.append(build_message_html(msg))
         chunks.append("<hr>")
 
     chunks.append("</div>")
+    return "\n".join(chunks).strip()
+
+
+def _build_message_markdown_lines(message: dict) -> List[str]:
+    """Build Markdown lines for a single message export."""
+    role = message.get("role", "assistant")
+    role_title = "User" if role == "user" else "Assistant"
+    lines: List[str] = [f"**{role_title}**"]
+
+    doc_lines, img_lines, message_text = _extract_export_info(message.get("content", ""))
+
+    if doc_lines or img_lines:
+        lines.append("")
+        lines.append("Attachments:")
+        lines.extend(doc_lines)
+        lines.extend(img_lines)
+
+    if message_text:
+        lines.append("")
+        lines.append(message_text)
+
+    lines.append("")
+    return lines
+
+
+def build_message_markdown(message: dict) -> str:
+    """Build clipboard-friendly Markdown for one message turn."""
+    return "\n".join(_build_message_markdown_lines(message)).strip() + "\n"
+
+
+def build_message_html(message: dict) -> str:
+    """Build clipboard-friendly HTML for one message turn."""
+    chunks: List[str] = []
+    role = message.get("role", "assistant")
+    role_title = "User" if role == "user" else "Assistant"
+    chunks.append(f"<p><strong>{html_escape(role_title)}</strong></p>")
+
+    doc_lines, img_lines, message_text = _extract_export_info(message.get("content", ""))
+
+    if doc_lines or img_lines:
+        chunks.append("<p><strong>Attachments:</strong></p>")
+        chunks.append("<ul>")
+        for line in (doc_lines + img_lines):
+            item = line.lstrip("- ").strip()
+            chunks.append("<li>" + _inline_md_to_html(item) + "</li>")
+        chunks.append("</ul>")
+
+    if message_text:
+        chunks.append(_md_to_html_basic(message_text))
+
     return "\n".join(chunks).strip()

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -32,6 +32,8 @@ from ephemeral.config import (
 from ephemeral.export import (
     build_conversation_html,
     build_conversation_markdown,
+    build_message_html,
+    build_message_markdown,
     build_message_text,
 )
 from ephemeral.stream_filter import ThinkStreamFilter, strip_think_blocks
@@ -342,6 +344,185 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
     st.iframe(iframe_src, height=58, width="stretch")
 
 
+def render_turn_copy_button(export_text_plain: str, export_html: str, button_id: str) -> None:
+    """Inline per-turn copy button with rich-copy fallback sequence."""
+    safe_plain = html_escape(export_text_plain)
+    hover_tip = "Copy this message"
+    normalized_button_id = "".join(ch if (ch.isalnum() or ch in "-_") else "-" for ch in button_id)
+    safe_button_id = html_escape(normalized_button_id, quote=True)
+
+    iframe_html = f"""
+        <meta charset="utf-8" />
+        <style>
+          html, body {{
+            margin: 0;
+            padding: 0;
+            background: transparent;
+          }}
+          .turn-copy {{
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            width: 100%;
+          }}
+          #turn-copy-btn-{safe_button_id} {{
+            box-sizing: border-box;
+            background: #FFFFFF;
+            color: #1d2a44;
+            border: 1px solid #dce2ee;
+            font-weight: 500;
+            font-size: 0.82rem;
+            font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", Roboto, sans-serif;
+            line-height: 1;
+            padding: 0.30rem 0.55rem;
+            border-radius: 999px;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: all .15s ease;
+          }}
+          #turn-copy-btn-{safe_button_id}:hover {{
+            border-color: #b6c3df;
+            background: #f7f9fe;
+          }}
+          #turn-copy-btn-{safe_button_id}:active {{
+            background: #eef0ff !important;
+            border-color: #99a7ff !important;
+          }}
+          #turn-copy-btn-{safe_button_id}.copied {{
+            background: #4F5BEA !important;
+            color: #FFFFFF !important;
+            border-color: #4F5BEA !important;
+          }}
+          #turn-copy-btn-{safe_button_id}.failed {{
+            background: #B00020 !important;
+            color: #FFFFFF !important;
+            border-color: #B00020 !important;
+          }}
+        </style>
+
+        <div class="turn-copy">
+          <button id="turn-copy-btn-{safe_button_id}" title="{html_escape(hover_tip)}">⧉ Copy</button>
+        </div>
+
+        <textarea id="turn-copy-plain-{safe_button_id}"
+                  style="position:absolute; left:-9999px; top:-9999px;">{safe_plain}</textarea>
+
+        <div id="turn-copy-rich-{safe_button_id}"
+             contenteditable="true"
+             style="position:absolute; left:-9999px; top:-9999px; width:900px;">
+          {export_html}
+        </div>
+
+        <script>
+          const btn = document.getElementById("turn-copy-btn-{safe_button_id}");
+          const plain = document.getElementById("turn-copy-plain-{safe_button_id}");
+          const rich = document.getElementById("turn-copy-rich-{safe_button_id}");
+          const originalLabel = btn.textContent;
+
+          function flash(stateClass, label, ms) {{
+            btn.disabled = true;
+            btn.classList.add(stateClass);
+            btn.textContent = label;
+
+            window.setTimeout(() => {{
+              btn.disabled = false;
+              btn.classList.remove(stateClass);
+              btn.textContent = originalLabel;
+            }}, ms);
+          }}
+
+          function copySelectionFrom(el) {{
+            const selection = window.getSelection();
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            el.focus();
+
+            let ok = false;
+            try {{
+              ok = document.execCommand("copy");
+            }} catch (e) {{
+              ok = false;
+            }}
+
+            selection.removeAllRanges();
+            return ok;
+          }}
+
+          function copyWithExecHtml() {{
+            let copied = false;
+            const onCopy = (event) => {{
+              try {{
+                event.preventDefault();
+                event.clipboardData.setData("text/plain", plain.value);
+                event.clipboardData.setData("text/html", rich.innerHTML);
+                copied = true;
+              }} catch (e) {{
+                copied = false;
+              }}
+            }};
+
+            document.addEventListener("copy", onCopy, {{ once: true }});
+
+            try {{
+              document.execCommand("copy");
+            }} catch (e) {{
+              copied = false;
+            }}
+
+            return copied;
+          }}
+
+          function copyPlain() {{
+            plain.focus();
+            plain.select();
+            let ok = false;
+            try {{
+              ok = document.execCommand("copy");
+            }} catch (e) {{
+              ok = false;
+            }}
+            return ok;
+          }}
+
+          async function copyWithClipboardApi() {{
+            if (!navigator.clipboard || !window.ClipboardItem) {{
+              return false;
+            }}
+
+            try {{
+              const item = new ClipboardItem({{
+                "text/plain": new Blob([plain.value], {{ type: "text/plain;charset=utf-8" }}),
+                "text/html": new Blob([rich.innerHTML], {{ type: "text/html;charset=utf-8" }}),
+              }});
+              await navigator.clipboard.write([item]);
+              return true;
+            }} catch (e) {{
+              return false;
+            }}
+          }}
+
+          btn.addEventListener("click", async () => {{
+            const modernOk = await copyWithClipboardApi();
+            const eventOk = modernOk ? true : copyWithExecHtml();
+            const richOk = eventOk ? true : copySelectionFrom(rich);
+            const ok = richOk || copyPlain();
+
+            if (ok) {{
+              flash("copied", "Copied", 850);
+            }} else {{
+              flash("failed", "Copy failed", 1500);
+            }}
+          }});
+        </script>
+        """
+    iframe_src = "data:text/html;charset=utf-8;base64," + base64.b64encode(
+        iframe_html.encode("utf-8")
+    ).decode("ascii")
+    st.iframe(iframe_src, height=38, width="stretch")
+
+
 # ── Session state ─────────────────────────────────────────────────
 st.session_state.setdefault("messages", [])
 st.session_state.setdefault("show_welcome", True)
@@ -534,6 +715,10 @@ def render_content(content: Union[str, list]) -> None:
 for m in st.session_state.messages:
     with styled_chat_message(m["role"], m.get("id")):
         render_content(m["content"])
+        turn_copy_md = build_message_markdown(m)
+        turn_copy_html = build_message_html(m)
+        turn_copy_id = m.get("id") or str(uuid.uuid4())
+        render_turn_copy_button(turn_copy_md, turn_copy_html, turn_copy_id)
 
 
 # ── Mobile convenience button ─────────────────────────────────────

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -3,6 +3,8 @@ from ephemeral.export import (
     _md_to_html_basic,
     build_conversation_html,
     build_conversation_markdown,
+    build_message_html,
+    build_message_markdown,
 )
 
 
@@ -61,6 +63,28 @@ def test_markdown_and_html_build_and_escape():
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
     assert "&lt;div&gt;content&lt;/div&gt;" in html
     assert "<script>" not in html
+
+
+def test_single_message_builders_match_turn_expectations():
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "📄 *doc1.pdf*"},
+            {"type": "text", "text": "hello **world**"},
+        ],
+    }
+
+    md = build_message_markdown(message)
+    assert "**Assistant**" in md
+    assert "Attachments:" in md
+    assert "- 📄 doc1.pdf" in md
+    assert "hello **world**" in md
+
+    html = build_message_html(message)
+    assert "<strong>Assistant</strong>" in html
+    assert "<strong>Attachments:</strong>" in html
+    assert "<li>📄 doc1.pdf</li>" in html
+    assert "<p>hello <strong>world</strong></p>" in html
 
 
 def test_md_to_html_basic_formats():


### PR DESCRIPTION
### Motivation
- Provide a small inline "Copy" control on each chat turn so users can quickly copy a single message with preserved rich formatting. 
- Reuse the existing robust rich-clipboard strategy from the sidebar copy feature to keep behavior consistent across per-turn and full-conversation copy flows.

### Description
- Added `render_turn_copy_button(...)` to `ephemeral_app.py`, which embeds a compact inline copy button as a sandboxed iframe and implements the same rich-copy fallback sequence (Clipboard API → `copy` event HTML injection → selection copy → plain-text fallback).
- Wired per-turn copy into the chat render loop so each message calls `build_message_markdown(...)` and `build_message_html(...)` and then `render_turn_copy_button(...)` under the rendered message.
- Refactored `ephemeral/export.py` to add `_build_message_markdown_lines()`, `build_message_markdown()`, and `build_message_html()`, and updated `build_conversation_markdown()`/`build_conversation_html()` to reuse the new per-message builders for consistent output.
- Normalized message IDs for safe DOM use when constructing per-turn iframe element IDs and added unit tests to validate the single-message export builders in `tests/test_export.py`.

### Testing
- Verified Python syntax with `python -m py_compile ephemeral_app.py ephemeral/*.py`, which succeeded.
- Ran the test suite with `python -m pytest -q`, and all tests passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd022eca083288d195c32c04ed178)