### PR TITLE
Show icon-only per-message copy button

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -401,7 +401,7 @@ def render_turn_copy_button(export_text_plain: str, export_html: str, button_id:
         </style>
 
         <div class="turn-copy">
-          <button id="turn-copy-btn-{safe_button_id}" title="{html_escape(hover_tip)}">⧉ Copy</button>
+          <button id="turn-copy-btn-{safe_button_id}" title="{html_escape(hover_tip)}" aria-label="{html_escape(hover_tip)}">⧉</button>
         </div>
 
         <textarea id="turn-copy-plain-{safe_button_id}"


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in message UI by removing the redundant visible "Copy" label since users recognize the copy icon.

### Description
- Updated the inline per-message copy button in `ephemeral_app.py` to render the copy icon only (`⧉`) and added an `aria-label` to preserve accessibility while keeping all existing copy behavior intact.

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd3a75e60832886e0b0c92c586c80)