### PR TITLE
Improve copy/paste formatting fidelity for per-message and conversation copy

### DIFF
--- a/ephemeral/export.py
+++ b/ephemeral/export.py
@@ -123,6 +123,7 @@ def _md_block_to_html(md_block: str) -> str:
     out: List[str] = []
     para: List[str] = []
     list_stack: List[str] = []
+    list_item_open: List[bool] = []
 
     def _list_indent_level(raw_line: str) -> int:
         """Return list nesting level from leading whitespace (2 spaces per level)."""
@@ -136,25 +137,36 @@ def _md_block_to_html(md_block: str) -> str:
             out.append("<p>" + "<br>".join(para) + "</p>")
             para = []
 
-    def close_lists() -> None:
-        while list_stack:
+    def close_lists(target_depth: int = 0) -> None:
+        while len(list_stack) > target_depth:
+            level = len(list_stack) - 1
+            if list_item_open[level]:
+                out.append("</li>")
+                list_item_open[level] = False
             out.append(f"</{list_stack.pop()}>")
+            list_item_open.pop()
 
-    def align_list_stack(target_level: int, list_tag: str) -> None:
-        while len(list_stack) > target_level + 1:
-            out.append(f"</{list_stack.pop()}>")
+    def _ensure_list_level(target_level: int, list_tag: str) -> None:
+        if len(list_stack) > target_level + 1:
+            close_lists(target_level + 1)
 
         if len(list_stack) == target_level + 1 and list_stack[-1] != list_tag:
-            out.append(f"</{list_stack.pop()}>")
+            close_lists(target_level)
 
         while len(list_stack) < target_level + 1:
             out.append(f"<{list_tag}>")
             list_stack.append(list_tag)
+            list_item_open.append(False)
 
-        if list_stack and list_stack[-1] != list_tag:
-            out.append(f"</{list_stack.pop()}>")
-            out.append(f"<{list_tag}>")
-            list_stack.append(list_tag)
+    def append_list_item(raw_line: str, list_tag: str, item_text: str) -> None:
+        target_level = _list_indent_level(raw_line)
+        _ensure_list_level(target_level, list_tag)
+
+        if list_item_open[target_level]:
+            out.append("</li>")
+
+        out.append("<li>" + _inline_md_to_html(item_text))
+        list_item_open[target_level] = True
 
     for raw in lines:
         line = raw or ""
@@ -181,15 +193,13 @@ def _md_block_to_html(md_block: str) -> str:
         m = re.match(r"^\s*[-*•]\s+(.*)$", line)
         if m:
             flush_para()
-            align_list_stack(_list_indent_level(line), "ul")
-            out.append("<li>" + _inline_md_to_html(m.group(1)) + "</li>")
+            append_list_item(line, "ul", m.group(1))
             continue
 
         m = re.match(r"^\s*\d+\.\s+(.*)$", line)
         if m:
             flush_para()
-            align_list_stack(_list_indent_level(line), "ol")
-            out.append("<li>" + _inline_md_to_html(m.group(1)) + "</li>")
+            append_list_item(line, "ol", m.group(1))
             continue
 
         close_lists()

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -285,6 +285,12 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
             }};
 
             document.addEventListener("copy", onCopy, {{ once: true }});
+            const selection = window.getSelection();
+            const range = document.createRange();
+            range.selectNodeContents(rich);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            rich.focus();
 
             try {{
               document.execCommand("copy");
@@ -292,6 +298,7 @@ def render_copy_button(export_text_plain: str, export_html: str) -> None:
               copied = false;
             }}
 
+            selection.removeAllRanges();
             return copied;
           }}
 
@@ -464,6 +471,12 @@ def render_turn_copy_button(export_text_plain: str, export_html: str, button_id:
             }};
 
             document.addEventListener("copy", onCopy, {{ once: true }});
+            const selection = window.getSelection();
+            const range = document.createRange();
+            range.selectNodeContents(rich);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            rich.focus();
 
             try {{
               document.execCommand("copy");
@@ -471,6 +484,7 @@ def render_turn_copy_button(export_text_plain: str, export_html: str, button_id:
               copied = false;
             }}
 
+            selection.removeAllRanges();
             return copied;
           }}
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -124,6 +124,7 @@ def test_md_to_html_basic_preserves_nested_bullets():
     html = _md_to_html_basic(md)
     assert "<ul>" in html
     assert html.count("<ul>") >= 2
-    assert "<li>Parent</li>" in html
-    assert "<li>Child A</li>" in html
-    assert "<li>Child B</li>" in html
+    assert "<li>Parent" in html
+    assert "<li>Parent\n<ul>" in html
+    assert "<li>Child A\n</li>" in html
+    assert "<li>Child B\n</li>" in html


### PR DESCRIPTION
### Motivation
- Users reported that copied message content lost bolding and nested list structure when pasted into editors like Google Docs or Word, indicating the rich-HTML clipboard path was not reliably used and nested lists were being emitted as invalid HTML.
- The export path should produce valid nested `<ul>/<ol>` HTML and the copy fallback should more reliably place `text/html` on the clipboard to preserve formatting.

### Description
- Fixed the Markdown-to-HTML list renderer in `ephemeral/export.py` to emit correct nested-list HTML by tracking open list levels and open list items and by introducing `append_list_item`, `_ensure_list_level`, and an improved `close_lists` implementation. 
- Strengthened the rich-copy fallback in `ephemeral_app.py` (both sidebar conversation copy and per-turn copy) by explicitly selecting the rich HTML node before calling `document.execCommand("copy")` and clearing the selection afterward to improve the chance that `text/html` is written to the clipboard. 
- Updated `tests/test_export.py` expectations to match the corrected nested-list HTML output so future regressions are detected.

### Testing
- Ran syntax check with `python -m py_compile ephemeral_app.py ephemeral/*.py` which succeeded. 
- Ran the focused test module with `python -m pytest tests/test_export.py` which passed. 
- Ran the full test suite with `python -m pytest` which completed successfully (`28 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf33ebf188328ac44b8ce2f63f859)