### PR TITLE
Polish chat avatars and message bubble visuals

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -37,6 +37,10 @@
     --color-user-msg-border: #99a7ff;
     --color-asst-msg-bg: #ffffff;
     --color-asst-msg-border: #7f8cff;
+    --color-user-avatar-bg: linear-gradient(160deg, #f4f6ff 0%, #e5eaff 100%);
+    --color-user-avatar-icon: #4a56d8;
+    --color-asst-avatar-bg: linear-gradient(160deg, #f2f3ff 0%, #e3e8ff 100%);
+    --color-asst-avatar-icon: #4955d6;
 }
 
 html,
@@ -400,8 +404,8 @@ button[title="View fullscreen"] {
 [class*="st-key-user_"] [data-testid="stChatMessage"] > div {
     flex-direction: row-reverse;
     justify-content: flex-start;
-    align-items: flex-end;
-    gap: 0.65rem;
+    align-items: center;
+    gap: 0.72rem;
     width: fit-content;
     max-width: min(78ch, 86%);
     margin-left: auto;
@@ -412,11 +416,11 @@ button[title="View fullscreen"] {
 [class*="st-key-user_"] [data-testid="stChatMessageContent"] {
     margin-left: auto;
     text-align: left;
-    background: linear-gradient(180deg, #f2f4ff 0%, #ebefff 100%);
-    border-radius: 16px 16px 6px 16px;
-    border: 1px solid #d8defe;
-    box-shadow: 0 2px 8px rgba(74, 91, 176, 0.08);
-    padding: 0.62rem 0.86rem;
+    background: linear-gradient(180deg, #f5f7ff 0%, #eef2ff 100%);
+    border-radius: 16px 16px 8px 16px;
+    border: 1px solid #d7defe;
+    box-shadow: 0 4px 14px rgba(74, 91, 176, 0.09);
+    padding: 0.65rem 0.92rem;
     width: fit-content;
     max-width: min(72ch, 100%);
     display: inline-block;
@@ -428,12 +432,13 @@ button[title="View fullscreen"] {
     border: 1px solid #dbe1ef !important;
     border-left: 4px solid var(--color-asst-msg-border) !important;
     box-shadow: 0 5px 16px rgba(30, 44, 77, 0.07) !important;
+    border-radius: 18px !important;
 }
 
 /* Streamlit internal test ID: content wrapper inside chat message in 1.56. */
 [class*="st-key-assistant-"] [data-testid="stChatMessageContent"],
 [class*="st-key-assistant_"] [data-testid="stChatMessageContent"] {
-    padding: 0.58rem 0.65rem 0.35rem;
+    padding: 0.62rem 0.72rem 0.4rem;
 }
 
 /* Markdown readability inside assistant cards. */
@@ -534,14 +539,43 @@ button[title="View fullscreen"] {
 }
 
 /* Streamlit internal avatar test IDs in 1.56 chat message widgets. */
+[data-testid="stChatMessageAvatarUser"],
+[data-testid="stChatMessageAvatarAssistant"] {
+    width: 2.15rem;
+    height: 2.15rem;
+    border-radius: 999px;
+    display: grid;
+    place-items: center;
+    border: 1px solid #d4dcf8;
+    box-shadow: 0 4px 12px rgba(40, 55, 104, 0.12);
+}
+
 [data-testid="chatAvatarIcon-user"] {
-    background: #e3e8ff !important;
-    color: #4458e6 !important;
+    background: var(--color-user-avatar-bg) !important;
+    color: var(--color-user-avatar-icon) !important;
+    border-radius: 999px !important;
+    border: 1px solid #d5ddff !important;
+    width: 2.15rem !important;
+    height: 2.15rem !important;
+    display: inline-grid !important;
+    place-items: center !important;
+    font-size: 1.04rem !important;
+    line-height: 1 !important;
+    box-shadow: 0 3px 10px rgba(66, 82, 161, 0.15);
 }
 
 [data-testid="chatAvatarIcon-assistant"] {
-    background: #e8ecff !important;
-    color: #4b57dc !important;
+    background: var(--color-asst-avatar-bg) !important;
+    color: var(--color-asst-avatar-icon) !important;
+    border-radius: 999px !important;
+    border: 1px solid #d4dcff !important;
+    width: 2.15rem !important;
+    height: 2.15rem !important;
+    display: inline-grid !important;
+    place-items: center !important;
+    font-size: 1.04rem !important;
+    line-height: 1 !important;
+    box-shadow: 0 3px 10px rgba(66, 82, 161, 0.15);
 }
 
 /* Streamlit internal test IDs: chat input dock and input wrapper. */


### PR DESCRIPTION
### Motivation
- Improve chat turn visuals to better match the provided polished mockup by making avatars and message bubbles feel more professional and visually distinct.
- Keep styling changes isolated to CSS so runtime behavior and privacy constraints remain unchanged.

### Description
- Updated `theme.css` to add avatar color tokens in `:root` for centralized tuning and theming.
- Reworked user bubble gradient, corner radii, border, padding, spacing, and shadow to strengthen visual hierarchy and alignment with the mockup.
- Adjusted assistant card padding and added a subtle rounded shape for more balanced proportions.
- Redesigned user/assistant avatars as circular gradient badges with consistent sizing, borders, and shadows while preserving existing Streamlit role wrapper selectors (`st-key-user-*` / `st-key-assistant-*`).

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf712b8a08328a0020b3ec6031506)