### PR TITLE
Polish chat avatars and per-turn copy icon styling

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -144,7 +144,7 @@ def styled_chat_message(role: str, message_id: str = None):
     normalized_role = "user" if role == "user" else "assistant"
     key = f"{normalized_role}-{message_id}" if message_id else f"{normalized_role}-{uuid.uuid4()}"
     chat_kwargs = {
-        "avatar": ":material/person:" if normalized_role == "user" else ":material/auto_awesome:",
+        "avatar": ":material/account_circle:" if normalized_role == "user" else ":material/assistant:",
     }
     if "width" in inspect.signature(st.chat_message).parameters:
         chat_kwargs["width"] = "content" if normalized_role == "user" else "stretch"
@@ -374,26 +374,26 @@ def render_turn_copy_button(export_text_plain: str, export_html: str, button_id:
           }}
           #turn-copy-btn-{safe_button_id} {{
             box-sizing: border-box;
-            background: #FFFFFF;
+            width: 2.05rem;
+            height: 2.05rem;
+            display: inline-grid;
+            place-items: center;
+            background: linear-gradient(180deg, #ffffff 0%, #f6f8ff 100%);
             color: #1d2a44;
             border: 1px solid #dce2ee;
-            font-weight: 500;
-            font-size: 0.82rem;
-            font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Segoe UI", Roboto, sans-serif;
-            line-height: 1;
-            padding: 0.30rem 0.55rem;
             border-radius: 999px;
             cursor: pointer;
-            white-space: nowrap;
             transition: all .15s ease;
           }}
           #turn-copy-btn-{safe_button_id}:hover {{
             border-color: #b6c3df;
-            background: #f7f9fe;
+            background: #ffffff;
+            box-shadow: 0 2px 8px rgba(50, 68, 118, 0.14);
           }}
           #turn-copy-btn-{safe_button_id}:active {{
             background: #eef0ff !important;
             border-color: #99a7ff !important;
+            box-shadow: none !important;
           }}
           #turn-copy-btn-{safe_button_id}.copied {{
             background: #4F5BEA !important;
@@ -405,10 +405,24 @@ def render_turn_copy_button(export_text_plain: str, export_html: str, button_id:
             color: #FFFFFF !important;
             border-color: #B00020 !important;
           }}
+          #turn-copy-btn-{safe_button_id} svg {{
+            width: 0.95rem;
+            height: 0.95rem;
+            stroke: currentColor;
+            fill: none;
+            stroke-width: 1.8;
+            stroke-linecap: round;
+            stroke-linejoin: round;
+          }}
         </style>
 
         <div class="turn-copy">
-          <button id="turn-copy-btn-{safe_button_id}" title="{html_escape(hover_tip)}" aria-label="{html_escape(hover_tip)}">⧉</button>
+          <button id="turn-copy-btn-{safe_button_id}" title="{html_escape(hover_tip)}" aria-label="{html_escape(hover_tip)}">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <rect x="9" y="9" width="11" height="11" rx="2"></rect>
+              <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+            </svg>
+          </button>
         </div>
 
         <textarea id="turn-copy-plain-{safe_button_id}"
@@ -424,7 +438,7 @@ def render_turn_copy_button(export_text_plain: str, export_html: str, button_id:
           const btn = document.getElementById("turn-copy-btn-{safe_button_id}");
           const plain = document.getElementById("turn-copy-plain-{safe_button_id}");
           const rich = document.getElementById("turn-copy-rich-{safe_button_id}");
-          const originalLabel = btn.textContent;
+          const iconMarkup = btn.innerHTML;
 
           function flash(stateClass, label, ms) {{
             btn.disabled = true;
@@ -434,7 +448,7 @@ def render_turn_copy_button(export_text_plain: str, export_html: str, button_id:
             window.setTimeout(() => {{
               btn.disabled = false;
               btn.classList.remove(stateClass);
-              btn.textContent = originalLabel;
+              btn.innerHTML = iconMarkup;
             }}, ms);
           }}
 

--- a/theme.css
+++ b/theme.css
@@ -541,41 +541,55 @@ button[title="View fullscreen"] {
 /* Streamlit internal avatar test IDs in 1.56 chat message widgets. */
 [data-testid="stChatMessageAvatarUser"],
 [data-testid="stChatMessageAvatarAssistant"] {
-    width: 2.15rem;
-    height: 2.15rem;
+    width: 2.2rem;
+    height: 2.2rem;
     border-radius: 999px;
     display: grid;
     place-items: center;
-    border: 1px solid #d4dcf8;
-    box-shadow: 0 4px 12px rgba(40, 55, 104, 0.12);
+    border: 1px solid #dce3f8;
+    background: #ffffff;
+    box-shadow: 0 3px 10px rgba(40, 55, 104, 0.1);
 }
 
 [data-testid="chatAvatarIcon-user"] {
-    background: var(--color-user-avatar-bg) !important;
-    color: var(--color-user-avatar-icon) !important;
+    background: linear-gradient(180deg, #ffffff 0%, #f6f8ff 100%) !important;
+    color: #4a5be7 !important;
     border-radius: 999px !important;
-    border: 1px solid #d5ddff !important;
-    width: 2.15rem !important;
-    height: 2.15rem !important;
+    border: 1px solid #d9e0ff !important;
+    width: 2.2rem !important;
+    height: 2.2rem !important;
     display: inline-grid !important;
     place-items: center !important;
-    font-size: 1.04rem !important;
+    font-size: 1.08rem !important;
     line-height: 1 !important;
-    box-shadow: 0 3px 10px rgba(66, 82, 161, 0.15);
+    box-shadow: 0 3px 10px rgba(66, 82, 161, 0.12);
 }
 
 [data-testid="chatAvatarIcon-assistant"] {
-    background: var(--color-asst-avatar-bg) !important;
-    color: var(--color-asst-avatar-icon) !important;
-    border-radius: 999px !important;
-    border: 1px solid #d4dcff !important;
-    width: 2.15rem !important;
-    height: 2.15rem !important;
+    background: linear-gradient(180deg, #ffffff 0%, #f3f5ff 100%) !important;
+    color: #4f5bea !important;
+    border-radius: 12px !important;
+    border: 1px solid #d7defe !important;
+    width: 2.2rem !important;
+    height: 2.2rem !important;
     display: inline-grid !important;
     place-items: center !important;
-    font-size: 1.04rem !important;
+    font-size: 1.06rem !important;
     line-height: 1 !important;
-    box-shadow: 0 3px 10px rgba(66, 82, 161, 0.15);
+    box-shadow: 0 3px 10px rgba(66, 82, 161, 0.13);
+}
+
+/* Streamlit 1.56 internals: Material Symbols render as inline SVG in avatar nodes. */
+[data-testid="chatAvatarIcon-user"] svg,
+[data-testid="chatAvatarIcon-assistant"] svg {
+    width: 1.05rem !important;
+    height: 1.05rem !important;
+    display: block !important;
+}
+
+[data-testid="chatAvatarIcon-user"] svg * ,
+[data-testid="chatAvatarIcon-assistant"] svg * {
+    fill: currentColor !important;
 }
 
 /* Streamlit internal test IDs: chat input dock and input wrapper. */


### PR DESCRIPTION
### Motivation
- Improve the visual quality of chat avatars and the per-turn copy control to better match the provided mockup and the overall UI polish.
- Replace basic text glyphs and default avatar symbols with higher-fidelity icon choices and CSS so avatars and inline controls look consistent and elevated.

### Description
- Swapped avatar material symbols in `styled_chat_message` to `:material/account_circle:` for the user and `:material/assistant:` for the assistant to provide a cleaner baseline iconography (`ephemeral_app.py`).
- Reworked per-turn copy UI in `render_turn_copy_button` to use a circular control with an inline SVG copy icon and improved sizing/hover/active/copy-state styles and behavior (`ephemeral_app.py`).
- Polished avatar surfaces in `theme.css` including size, border, gradients, shadows, assistant corner radius, and explicit SVG `fill` handling so Material Symbols render with intended color and weight (`theme.css`).
- Kept existing copy behavior and restores the SVG markup after flash states by capturing and restoring the button `innerHTML` in the flash/reset logic (`ephemeral_app.py`).

### Testing
- Verified Python syntax with `python -m py_compile ephemeral_app.py ephemeral/*.py` and the compile step completed successfully.
- No additional automated tests were run in this rollout (visual check expected in browser / CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf86a72708328b219dc35c65bdbdd)