### PR TITLE
Align user avatar to right of user chat bubbles

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -402,7 +402,9 @@ button[title="View fullscreen"] {
 /* Streamlit internal structure: user row wrapper to emulate right aligned bubbles + avatar. */
 [class*="st-key-user-"] [data-testid="stChatMessage"] > div,
 [class*="st-key-user_"] [data-testid="stChatMessage"] > div {
-    flex-direction: row;
+    /* Streamlit 1.56 internals: chat row wraps avatar + message content as siblings.
+       Use row-reverse so user avatar renders on the right side of the bubble. */
+    flex-direction: row-reverse;
     justify-content: flex-end;
     align-items: center;
     gap: 0.72rem;


### PR DESCRIPTION
### Motivation
- Adjust the user-chat layout so the user's avatar appears to the right of their message bubble for visual symmetry with assistant messages.

### Description
- Update `theme.css` to set `flex-direction: row-reverse` on the user chat row selector (`[class*="st-key-user-"] [data-testid="stChatMessage"] > div`) and add an explanatory inline comment about Streamlit 1.56 internals.

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` and `python -m pytest -q` with all tests passing (28 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfbe2b81883288a2d40b123000a47)