### PR TITLE
Fix user avatar side in Streamlit chat by targeting stChatMessage container

### DIFF
--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -58,6 +58,13 @@ def test_theme_css_keeps_compact_right_aligned_user_message_contract():
     assert "width: fit-content;" in css
 
 
+def test_theme_css_targets_chat_message_container_for_avatar_ordering():
+    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
+    assert '[class*="st-key-user-"] [data-testid="stChatMessage"],' in css
+    assert '[class*="st-key-user-"] [data-testid="stChatMessage"] > div' not in css
+    assert 'flex-direction: row-reverse;' in css
+
+
 def test_theme_css_has_no_external_font_or_cdn_imports():
     css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8").lower()
     forbidden_patterns = [

--- a/theme.css
+++ b/theme.css
@@ -399,9 +399,10 @@ button[title="View fullscreen"] {
     margin: 0 0 0.35rem 0;
 }
 
-/* Streamlit internal structure: user row wrapper to emulate right aligned bubbles + avatar. */
-[class*="st-key-user-"] [data-testid="stChatMessage"] > div,
-[class*="st-key-user_"] [data-testid="stChatMessage"] > div {
+/* Streamlit 1.56 ChatMessage.tsx renders avatar + content as direct children of
+   [data-testid="stChatMessage"] (no intermediate row div), so target the container itself. */
+[class*="st-key-user-"] [data-testid="stChatMessage"],
+[class*="st-key-user_"] [data-testid="stChatMessage"] {
     /* Streamlit 1.56 internals: chat row wraps avatar + message content as siblings.
        Use row-reverse so user avatar renders on the right side of the bubble. */
     flex-direction: row-reverse;
@@ -442,9 +443,9 @@ button[title="View fullscreen"] {
     box-shadow: none !important;
 }
 
-/* Streamlit internal structure: assistant row wrapper with avatar outside the bubble on the left. */
-[class*="st-key-assistant-"] [data-testid="stChatMessage"] > div,
-[class*="st-key-assistant_"] [data-testid="stChatMessage"] > div {
+/* Same container-level targeting for assistant role to avoid brittle child combinators. */
+[class*="st-key-assistant-"] [data-testid="stChatMessage"],
+[class*="st-key-assistant_"] [data-testid="stChatMessage"] {
     flex-direction: row;
     justify-content: flex-start;
     align-items: center;


### PR DESCRIPTION
### Motivation
- User avatars for user messages remained on the left because the CSS targeted a non-existent/intermediate child element instead of the actual chat message flex container rendered by Streamlit 1.56. This change makes the user avatar render on the right to match right-aligned user bubbles.

### Description
- Changed role-scoped ordering rules in `theme.css` to target the chat message container itself instead of a `> div` child, replacing selectors like `[class*="st-key-user-"] [data-testid="stChatMessage"] > div` with `[class*="st-key-user-"] [data-testid="stChatMessage"]`, and applied the same container-level targeting for assistant rows for consistency (see `theme.css` lines ~402-415 and ~446-454). 
- Kept the existing `st-key-user-*` / `st-key-assistant-*` wrapper approach and all `:root` variables intact to preserve the styling architecture and AGENTS.md constraints. 
- Added a static contract test `test_theme_css_targets_chat_message_container_for_avatar_ordering` to `tests/test_ui_static_contracts.py` to prevent regression to the brittle child-combinator selector (see `tests/test_ui_static_contracts.py` lines ~61-66). 
- Documented the root-cause in CSS comments where the selector was changed to make the intent clear and less brittle against Streamlit DOM changes.

### Testing
- Ran syntax checks with `python -m py_compile ephemeral_app.py ephemeral/*.py`, which completed successfully with no errors. 
- Ran the test suite with `python -m pytest -q`, which passed: `29 passed` and the new contract test succeeded. 

Citations to changed files (approximate line ranges):
- `theme.css` — container-level selector and ordering rules (user block) at ~lines 402-415 and (assistant block) at ~lines 446-454. 
- `tests/test_ui_static_contracts.py` — new static contract test at ~lines 61-66.

Root cause (concise): the `flex-direction` was being applied to a child selector that did not correspond to the flex container Streamlit emits in 1.56, so avatar ordering never changed; applying `flex-direction: row-reverse` to `[data-testid="stChatMessage"]` (the actual flex container) fixes avatar placement.

References consulted: Streamlit `st.chat_message` docs and Streamlit 1.56 ChatMessage source indicating the container structure and test IDs (Streamlit docs and GitHub source for 1.56).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfdfcedb88328a4a66c96cf4113b4)