### PR TITLE
Remove duplicate test definitions in UI static contracts

### DIFF
--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -38,26 +38,6 @@ def test_theme_css_keeps_compact_right_aligned_user_message_contract():
     assert "width: fit-content;" in css
 
 
-def test_theme_css_has_streamlit_156_chat_input_contract_selectors():
-    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
-    assert '[data-testid="stChatInput"]' in css
-    assert '[data-testid="stChatInputTextArea"]' in css
-    assert '[data-testid="stChatInputSubmitButton"]' in css
-
-
-def test_theme_css_supports_sidebar_new_key_variants():
-    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
-    assert '[class*="st-key-sidebar_new"] .stButton > button' in css
-    assert '[class*="st-key-sidebar-new"] .stButton > button' in css
-
-
-def test_theme_css_keeps_compact_right_aligned_user_message_contract():
-    css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
-    assert '[class*="st-key-user-"] [data-testid="stChatMessage"]' in css
-    assert "margin-left: auto;" in css
-    assert "width: fit-content;" in css
-
-
 def test_theme_css_targets_chat_message_container_for_avatar_ordering():
     css = (REPO_ROOT / "theme.css").read_text(encoding="utf-8")
     assert '[class*="st-key-user-"] [data-testid="stChatMessage"],' in css


### PR DESCRIPTION
### Motivation
- Remove misleading duplicate test function definitions in `tests/test_ui_static_contracts.py` where three tests were declared twice and the first definitions were silently overwritten at import time.

### Description
- Deleted the second occurrences of `test_theme_css_has_streamlit_156_chat_input_contract_selectors`, `test_theme_css_supports_sidebar_new_key_variants`, and `test_theme_css_keeps_compact_right_aligned_user_message_contract` and kept the original definitions intact so no test logic changed.

### Testing
- Verified there are exactly 11 `test_` functions with a small `ast` check, ran `pytest tests/test_ui_static_contracts.py -q` which returned `11 passed`, and confirmed `initial_sidebar_state=304` remains in `ephemeral_app.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed32f85e688328864fbf73e454b103)