### PR TITLE
Use attachment metadata for ghost document cleanup

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -922,9 +922,8 @@ if prompt_in is not None:
             for part in parts
             if not (
                 part.get("type") == "text"
-                and part.get("text", "").strip().startswith("📄 *")
-                and part.get("text", "").strip().endswith("*")
-                and part.get("text", "").strip()[3:-1].strip() in dropped_set
+                and part.get("_attachment", {}).get("kind") == "document"
+                and part.get("_attachment", {}).get("name") in dropped_set
             )
         ]
 

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -89,3 +89,10 @@ def test_docker_service_name_defaults_are_preserved():
     config_text = (REPO_ROOT / "ephemeral/config.py").read_text(encoding="utf-8")
     assert 'LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")' in config_text
     assert 'TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")' in config_text
+
+
+def test_ghost_doc_cleanup_uses_attachment_metadata_not_marker_text():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert 'part.get("_attachment", {}).get("kind") == "document"' in app_text
+    assert 'part.get("_attachment", {}).get("name") in dropped_set' in app_text
+    assert 'startswith("\U0001f4c4 *")' not in app_text


### PR DESCRIPTION
### Motivation
- The ghost-document cleanup relied on fragile UI marker text parsing which broke when marker formatting changed, so the cleanup should use structured metadata instead.
- Preserve existing runtime behavior and Streamlit configuration, including `st.set_page_config(initial_sidebar_state=304)`.

### Description
- Replaced the marker-text based filter in `ephemeral_app.py` with a metadata-based filter that checks `part.get("_attachment", {}).get("kind") == "document"` and `part.get("_attachment", {}).get("name") in dropped_set`.
- Removed dependency on `startswith("📄 *")` for the cleanup path so it no longer depends on rendered marker text.
- Added a static contract test `test_ghost_doc_cleanup_uses_attachment_metadata_not_marker_text` to `tests/test_ui_static_contracts.py` that asserts the new metadata checks exist and that the old `startswith("📄 *")` pattern is absent.

### Testing
- Ran `pytest -q` which failed collection in a default environment due to module import paths (ModuleNotFoundError for `ephemeral`).
- Ran `PYTHONPATH=. pytest -q` which succeeded with `30 passed` and included the new static contract test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed435b4b3083289e443b4a547b024b)