### PR TITLE
Cache sidebar logo base64 encoding

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -137,6 +137,15 @@ else:
     )
 
 
+@st.cache_data(show_spinner=False)
+def _load_logo_b64(path: str = "static/ephemeral_logo.png") -> str:
+    """Read and base64-encode the logo once, cached across reruns."""
+    logo_path = pathlib.Path(path)
+    if logo_path.exists():
+        return base64.b64encode(logo_path.read_bytes()).decode("ascii")
+    return ""
+
+
 # ── Chat message wrapper for CSS styling ──────────────────────────
 @contextmanager
 def styled_chat_message(role: str, message_id: str = None):
@@ -560,9 +569,8 @@ st.session_state.setdefault("_vision_supported", None)
 
 # ── Sidebar ───────────────────────────────────────────────────────
 with st.sidebar:
-    logo_path = pathlib.Path("static/ephemeral_logo.png")
-    if logo_path.exists():
-        logo_b64 = base64.b64encode(logo_path.read_bytes()).decode("ascii")
+    logo_b64 = _load_logo_b64()
+    if logo_b64:
         st.markdown(
             f"""
             <div class="sidebar-brand">

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -96,3 +96,10 @@ def test_ghost_doc_cleanup_uses_attachment_metadata_not_marker_text():
     assert 'part.get("_attachment", {}).get("kind") == "document"' in app_text
     assert 'part.get("_attachment", {}).get("name") in dropped_set' in app_text
     assert 'startswith("\U0001f4c4 *")' not in app_text
+
+
+def test_sidebar_logo_encoding_is_cached():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert "@st.cache_data(show_spinner=False)" in app_text
+    assert "def _load_logo_b64(" in app_text
+    assert "logo_b64 = _load_logo_b64()" in app_text


### PR DESCRIPTION
### Motivation
- Avoid re-reading and base64-encoding the static sidebar logo on every Streamlit rerun to reduce unnecessary I/O and CPU work for a static asset.

### Description
- Add a cached helper `@st.cache_data(show_spinner=False) def _load_logo_b64(path: str = "static/ephemeral_logo.png") -> str:` immediately after the `SYSTEM_TMPL` block to read and base64-encode the logo once and cache the result.
- Replace the inline sidebar file-read logic with `logo_b64 = _load_logo_b64()` and keep the existing fallback branding branch unchanged.
- Add a static contract test `test_sidebar_logo_encoding_is_cached` in `tests/test_ui_static_contracts.py` that asserts the cache decorator, loader function, and sidebar call are present in `ephemeral_app.py`.
- Preserve `st.set_page_config(initial_sidebar_state=304)` exactly as required.

### Testing
- Running `pytest -q` in the default environment initially failed due to the test runner not having the repo on `PYTHONPATH` (import errors); this was an environment issue, not a code failure.
- Running `PYTHONPATH=. pytest -q` succeeded with `31 passed`, including the new `test_sidebar_logo_encoding_is_cached` test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed44489368832886cf2b592bc2cbc7)