### PR TITLE
Add LRU token cache and fix tokenizer availability flag

### DIFF
--- a/ephemeral/llm_client.py
+++ b/ephemeral/llm_client.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import re
+from collections import OrderedDict
 from typing import Dict, Optional
 
 import streamlit as st
@@ -171,8 +172,30 @@ def get_image_token_cost() -> int:
 
 
 # ── Token counting ────────────────────────────────────────────────
-def _get_token_cache() -> Dict[str, int]:
-    return st.session_state.setdefault("_token_count_cache", {})
+def _get_token_cache() -> OrderedDict:
+    """Return the session-scoped LRU token cache, creating it if needed."""
+    if "_token_count_cache" not in st.session_state:
+        st.session_state["_token_count_cache"] = OrderedDict()
+
+    cache = st.session_state["_token_count_cache"]
+
+    # Migration path for existing sessions that still have a plain dict.
+    if not isinstance(cache, OrderedDict):
+        cache = OrderedDict(cache)
+        st.session_state["_token_count_cache"] = cache
+
+    return cache
+
+
+def _cache_put(cache: OrderedDict, key: str, value: int) -> None:
+    """Insert into the token cache and evict the oldest entries when over capacity."""
+    cache[key] = value
+    cache.move_to_end(key)
+
+    if len(cache) > TOKEN_CACHE_MAX_ENTRIES:
+        evict_count = max(1, TOKEN_CACHE_MAX_ENTRIES // 4)
+        for _ in range(evict_count):
+            cache.popitem(last=False)
 
 
 def count_text_tokens(text: str) -> int:
@@ -188,21 +211,20 @@ def count_text_tokens(text: str) -> int:
         return 0
 
     cache = _get_token_cache()
-    if len(cache) > TOKEN_CACHE_MAX_ENTRIES:
-        cache.clear()
 
     key = hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()
     if key in cache:
+        cache.move_to_end(key)
         return cache[key]
 
     if not ENABLE_TOKEN_BUDGETING:
         n = _heuristic_token_estimate(text)
-        cache[key] = n
+        _cache_put(cache, key, n)
         return n
 
     if st.session_state.get("tokenizer_available") is False:
         n = _heuristic_token_estimate(text)
-        cache[key] = n
+        _cache_put(cache, key, n)
         return n
 
     tokenize_url = f"{_ollama_base_url()}/api/tokenize"
@@ -216,13 +238,14 @@ def count_text_tokens(text: str) -> int:
         if resp.status_code == 404:
             st.session_state["tokenizer_available"] = False
             n = _heuristic_token_estimate(text)
-            cache[key] = n
+            _cache_put(cache, key, n)
             return n
 
         resp.raise_for_status()
         payload = resp.json()
 
         tokens = payload.get("tokens")
+        tokenizer_ok = True
         if isinstance(tokens, list):
             n = len(tokens)
         elif isinstance(tokens, int):
@@ -230,14 +253,14 @@ def count_text_tokens(text: str) -> int:
         elif isinstance(tokens, str) and tokens.isdigit():
             n = int(tokens)
         else:
-            st.session_state["tokenizer_available"] = False
+            tokenizer_ok = False
             n = _heuristic_token_estimate(text)
 
-        st.session_state["tokenizer_available"] = True
-        cache[key] = n
+        st.session_state["tokenizer_available"] = tokenizer_ok
+        _cache_put(cache, key, n)
         return n
     except Exception:
         st.session_state["tokenizer_available"] = False
         n = _heuristic_token_estimate(text)
-        cache[key] = n
+        _cache_put(cache, key, n)
         return n

--- a/tests/test_llm_client_cache.py
+++ b/tests/test_llm_client_cache.py
@@ -1,0 +1,79 @@
+import hashlib
+from collections import OrderedDict
+from types import SimpleNamespace
+
+
+def _token_key(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()
+
+
+def test_cache_eviction_is_partial_not_total():
+    """Eviction should remove the oldest quarter, not clear the whole cache."""
+    from ephemeral import llm_client
+
+    cache = OrderedDict()
+    max_entries = llm_client.TOKEN_CACHE_MAX_ENTRIES
+    evict_count = max(1, max_entries // 4)
+
+    for i in range(max_entries + 4):
+        llm_client._cache_put(cache, str(i), i)
+
+    assert len(cache) == max_entries + 4 - evict_count
+    assert "0" not in cache
+    assert str(max_entries + 3) in cache
+
+
+def test_get_token_cache_migrates_plain_dict(monkeypatch):
+    """_get_token_cache should upgrade a plain dict to OrderedDict."""
+    from ephemeral import llm_client
+
+    session = {"_token_count_cache": {"x": 10}}
+    monkeypatch.setattr(llm_client, "st", SimpleNamespace(session_state=session))
+
+    result = llm_client._get_token_cache()
+
+    assert isinstance(result, OrderedDict)
+    assert result["x"] == 10
+    assert session["_token_count_cache"] is result
+
+
+def test_count_text_tokens_cache_hit_promotes_entry(monkeypatch):
+    """count_text_tokens should promote a cache hit to most-recently-used."""
+    from ephemeral import llm_client
+
+    key_a = _token_key("a")
+    key_b = _token_key("b")
+    session = {
+        "_token_count_cache": OrderedDict([(key_a, 1), (key_b, 2)]),
+        "tokenizer_available": False,
+    }
+    monkeypatch.setattr(llm_client, "st", SimpleNamespace(session_state=session))
+
+    assert llm_client.count_text_tokens("a") == 1
+    assert list(session["_token_count_cache"].keys()) == [key_b, key_a]
+
+
+def test_unrecognized_tokenizer_payload_marks_tokenizer_unavailable(monkeypatch):
+    """Unexpected tokenizer payloads should keep tokenizer_available=False."""
+    from ephemeral import llm_client
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"unexpected": "shape"}
+
+    session = {
+        "_token_count_cache": OrderedDict(),
+        "tokenizer_available": None,
+    }
+    monkeypatch.setattr(llm_client, "st", SimpleNamespace(session_state=session))
+    monkeypatch.setattr(llm_client, "ENABLE_TOKEN_BUDGETING", True)
+    monkeypatch.setattr(llm_client.requests, "post", lambda *args, **kwargs: FakeResponse())
+
+    expected = llm_client._heuristic_token_estimate("hello")
+    assert llm_client.count_text_tokens("hello") == expected
+    assert session["tokenizer_available"] is False


### PR DESCRIPTION
### Motivation
- Prevent large cache churn caused by clearing the entire token cache when capacity is exceeded and reduce avoidable cache misses. 
- Ensure the tokenizer availability state reflects actual tokenizer responses so unexpected `/api/tokenize` payloads mark the tokenizer as unavailable instead of being overwritten to available.

### Description
- Switched the session token cache to an `OrderedDict` by adding `from collections import OrderedDict` and replacing `_get_token_cache()` with an `OrderedDict`-backed implementation that migrates legacy plain `dict` sessions. 
- Added `_cache_put(cache, key, value)` to centralize cache writes, promote writes to MRU, and evict the oldest entries in partial batches (`evict_count = max(1, TOKEN_CACHE_MAX_ENTRIES // 4)`) instead of clearing the whole cache. 
- Updated `count_text_tokens()` to promote cache hits via `cache.move_to_end(key)`, remove the full-cache clear behavior, and route all cache writes through `_cache_put()`. 
- Fixed tokenizer status handling by introducing a `tokenizer_ok` flag when parsing `resp.json()` so unrecognized tokenizer payloads set `st.session_state["tokenizer_available"] = False` while valid payloads set it to `True`. 
- Added `tests/test_llm_client_cache.py` covering cache migration, partial eviction behavior, cache-hit MRU promotion, and unrecognized tokenizer payload fallback behavior.

### Testing
- Ran `PYTHONPATH=. pytest -q` and the full test suite passed (`35 passed`).
- Note: running `pytest -q` without `PYTHONPATH=.` in this environment raises import errors unrelated to the changes, so use `PYTHONPATH=. pytest -q` to run the tests.
- All new tests in `tests/test_llm_client_cache.py` passed as part of the suite run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed451d9f208328ba293e038ed370d6)