### PR TITLE
Configure pytest pythonpath for flat-layout package imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]


### PR DESCRIPTION
### Motivation
- Ensure `pytest -q` reliably includes the repository root on `sys.path` so tests can import the flat-layout `ephemeral` package without requiring `python -m pytest`.

### Description
- Add a repository-root `pyproject.toml` (or merge into an existing one) with the pytest configuration `pythonpath = ["."]` and `testpaths = ["tests"]` so pytest discovery/runs see the repo root and no application code or dependencies are changed.

### Testing
- Ran `python -m pytest -q` and `pytest -q`, and both succeeded (`40 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed49fb8d288328b58133fb8126615f)