### PR TITLE
Harden Streamlit UI smoke-test tooling for local/Codex runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,3 +55,6 @@ docker-compose.yml
 docker-compose.api.yml
 tests/
 requirements-dev.txt
+
+# Generated test artifacts
+artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ htmlcov/
 # OS files
 .DS_Store
 Thumbs.db
+
+# Generated test artifacts
+artifacts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,9 @@ You may also run:
 
 ## Browser/UI testing
 
+- UI smoke testing requires the Python Playwright package **and** a Chromium browser installed in the environment.
+- Playwright is a dev/test dependency only (in `requirements-dev.txt`), not a production dependency.
+- Generated screenshots under `artifacts/ui-smoke/` are test artifacts and should not be committed.
 - Browser smoke tests are useful for Streamlit UI and clipboard iframe behavior.
 - For UI, Streamlit, `theme.css`, or clipboard changes, run:
   - `python scripts/ui_smoke.py`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest>=8.0
 pytest-cov>=5.0
+playwright

--- a/scripts/ui_smoke.py
+++ b/scripts/ui_smoke.py
@@ -13,8 +13,17 @@ from typing import Optional
 from urllib.error import URLError
 from urllib.request import urlopen
 
-from playwright.sync_api import Error as PlaywrightError
-from playwright.sync_api import sync_playwright
+try:
+    from playwright.sync_api import Error as PlaywrightError
+    from playwright.sync_api import sync_playwright
+except ModuleNotFoundError as exc:
+    print(
+        "Playwright is not installed. Install development dependencies with "
+        "`python -m pip install -r requirements-dev.txt`, then install Chromium with "
+        "`python -m playwright install --with-deps chromium`.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from exc
 
 HOST = "127.0.0.1"
 PORT = 8501


### PR DESCRIPTION
### Motivation
- Make the UI smoke-test harness safer and clearer for local and Codex runs without changing application behavior. 
- Prevent generated screenshots from being committed or copied into Docker build contexts. 
- Provide an explicit, actionable error when the Playwright Python package is missing so users know how to install the dev tooling. 
- Declare Playwright as a dev/test dependency so CI and developers install the required package.

### Description
- Add `artifacts/` to `.gitignore` and `.dockerignore` to exclude generated UI smoke artifacts from VCS and Docker build contexts. 
- Add `playwright` (un-pinned) to `requirements-dev.txt` as a dev/test dependency. 
- Wrap the Playwright imports in `scripts/ui_smoke.py` in a `try/except ModuleNotFoundError` that prints a clear stderr message and exits nonzero with instructions to install dev deps and Chromium. 
- Add a short targeted note to `AGENTS.md` clarifying that UI smoke testing requires Playwright + Chromium, that Playwright is a dev/test dependency, and that `artifacts/ui-smoke/` screenshots are generated test artifacts and should not be committed.

### Testing
- Ran `python -m pytest -q`, which completed successfully (`42 passed`).
- Ran `pytest -q`, which completed successfully (`42 passed`).
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/ui_smoke.py`, which completed with no syntax errors. 
- Ran `bash scripts/validate_ui.sh`, which ran the test suite and the UI smoke script and reported the UI smoke test passed with generated screenshots under `artifacts/ui-smoke/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed63dbb9008328a5abe2b247a82567)