### PR TITLE
chore: remove two unused imports from ephemeral_app.py

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -18,7 +18,6 @@ from ephemeral.config import (
     DEBUG_MODE,
     ENABLE_TOKEN_BUDGETING,
     LLM_BASE_URL,
-    LLM_CONTEXT_TOKENS,
     LLM_MAX_TOKENS,
     LLM_MODEL_NAME,
     LLM_OUTPUT_RESERVE_TOKENS,
@@ -27,7 +26,6 @@ from ephemeral.config import (
     LLM_SHOW_REASONING,
     LLM_TEMPERATURE,
     LLM_TOP_P,
-    TIKA_URL,
 )
 from ephemeral.export import (
     build_conversation_html,


### PR DESCRIPTION
### Motivation
- Remove two unused configuration names (`LLM_CONTEXT_TOKENS` and `TIKA_URL`) from the import list in `ephemeral_app.py` to clean up dead imports while preserving runtime behavior.

### Description
- Deleted `LLM_CONTEXT_TOKENS` and `TIKA_URL` from the `from ephemeral.config import (...)` block in `ephemeral_app.py` and made no other changes to the file or repository.

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py`, `python -m pytest -q`, `bash scripts/validate.sh`, and `ruff check .`, and all commands completed successfully in this environment (`42 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed70ca1d408328a4beeeed808511d7)