### PR TITLE
Add Ruff to developer validation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ When reviewing Codex changes, treat the following as high-priority checks:
 - Verify Python syntax: `python -m py_compile ephemeral_app.py ephemeral/*.py`
 - Verify requirements install: `pip install -r requirements.txt && pip check`
 - Verify test tooling + run tests: `pip install -r requirements-dev.txt && python -m pytest`
+- Verify linting: `ruff check .`
 - Verify Markdown links resolve: all relative links in README.md and the deployment
   guide should point to files that exist in the repo.
 - Full stack test: `docker compose up -d --build` inside WSL2, then access
@@ -194,6 +195,7 @@ Run from the repository root:
 1. `python -m pytest -q`
 2. `pytest -q`
 3. `python -m py_compile ephemeral_app.py ephemeral/*.py`
+4. `ruff check .`
 
 You may also run:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest>=8.0
 pytest-cov>=5.0
 playwright
+ruff>=0.11

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -4,3 +4,4 @@ set -euo pipefail
 python -m pytest -q
 pytest -q
 python -m py_compile ephemeral_app.py ephemeral/*.py
+ruff check .


### PR DESCRIPTION
### Motivation
- Include Ruff as a dev-only linting tool so contributors run a consistent linter during normal validation.
- Surface linting in documented validation steps so the repository's contributor workflow matches automated checks.
- Keep the change tooling-only and avoid any runtime, container, UI, or production dependency changes.

### Description
- Added `ruff>=0.11` to `requirements-dev.txt` so Ruff is installed as a development dependency.
- Appended `ruff check .` to `scripts/validate.sh` to run Ruff in check mode as part of the standard validation flow while preserving existing sequencing.
- Updated `AGENTS.md` testing guidance to include `ruff check .` in both the testing checklist and the required validation steps so documentation matches behavior.
- No application code, Docker runtime images, UI, CSS, tests, or production dependencies were modified.

### Testing
- Ran `pip install -r requirements-dev.txt`, which failed in this environment due to repository/proxy access with the error: `ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 403 Forbidden'))` and `ERROR: Could not find a version that satisfies the requirement pytest-cov>=5.0`.
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py`, which succeeded with no errors.
- Ran `python -m pytest -q`, which succeeded with `42 passed`.
- Ran `bash scripts/validate.sh`, which succeeded (existing tests and compile checks passed and the script completed: `All checks passed!`).
- Ran `ruff check .`, which completed successfully (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed729e0e348328abd06067ad43eec8)