### PR TITLE
Update welcome copy, improve Playwright smoke test diagnostics, and adjust test expectation

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -268,7 +268,7 @@ if st.session_state.show_welcome:
                 <div class="feature-badge feature-badge-blue">+</div>
                 <div class="feature-copy">
                   <div class="feature-copy-strong">Attach files, not just prompts</div>
-                  <div class="feature-copy-muted">PDFs, Office files, spreadsheets, text, and more. Images work when the model supports them.</div>
+                  <div class="feature-copy-muted">Images, PDFs, Office files, spreadsheets, text, and more.</div>
                 </div>
               </div>
               <div class="welcome-feature" role="listitem">

--- a/scripts/ui_smoke.py
+++ b/scripts/ui_smoke.py
@@ -8,6 +8,7 @@ import socket
 import subprocess
 import sys
 import time
+import traceback
 from pathlib import Path
 from typing import Optional
 from urllib.error import URLError
@@ -140,9 +141,14 @@ def _capture_ui_screenshots() -> None:
             mobile.close()
             browser.close()
     except PlaywrightError as exc:
+        error_name = type(exc).__name__
+        error_detail = str(exc).strip() or "<no details provided>"
+        traceback_detail = "".join(traceback.format_exception_only(type(exc), exc)).strip()
         raise SmokeTestError(
-            "Playwright failed to launch Chromium or interact with the page. "
-            "Ensure Playwright + Chromium are installed in this environment."
+            "Playwright browser interaction failed.\n"
+            f"Error type: {error_name}\n"
+            f"Error detail: {error_detail}\n"
+            f"Playwright exception: {traceback_detail}"
         ) from exc
 
 

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -69,9 +69,7 @@ def test_welcome_state_copy_contracts():
     assert "Attach files, not just prompts" in app_text
     assert "Local and session-only" in app_text
     assert "Verify important answers" in app_text
-    assert (
-        "PDFs, Office files, spreadsheets, text, and more. Images work when the model supports them." in app_text
-    )
+    assert "Images, PDFs, Office files, spreadsheets, text, and more." in app_text
     assert "No account or saved chat history in this app. New Chat clears messages and uploads." in app_text
     assert (
         "This local model has no live web access and may be wrong, especially on current facts." in app_text


### PR DESCRIPTION
### Motivation
- Clarify the welcome banner copy to list supported attachment types more succinctly.
- Improve diagnostics in the UI smoke test so Playwright failures produce actionable error details.

### Description
- Replace the welcome feature text in `ephemeral_app.py` from the previous verbose sentence to: `Images, PDFs, Office files, spreadsheets, text, and more.`
- Enhance `scripts/ui_smoke.py` to import `traceback` and include the Playwright exception type, message, and a formatted exception snippet in the raised `SmokeTestError`.
- Update `tests/test_ui_static_contracts.py` to assert the new welcome copy string so the static contract test matches the updated UI text.

### Testing
- Ran `pytest tests/test_ui_static_contracts.py` to validate the updated assertion and the test passed.
- Ran the project's test suite with `pytest -q` and the tests completed successfully.
- Exercised the UI smoke script `scripts/ui_smoke.py` in an environment with Playwright installed to confirm improved error messaging on Playwright failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef85d01074832884a27a11e2233749)