### PR TITLE
Introduce Thinking Mode with separate reasoning effort and max_tokens handling

### DIFF
--- a/ephemeral/config.py
+++ b/ephemeral/config.py
@@ -84,6 +84,7 @@ LLM_TEMPERATURE = _float_env("LLM_TEMPERATURE", 0.7)
 LLM_TOP_P = _float_env("LLM_TOP_P", 0.8)
 LLM_PRESENCE_PENALTY = _float_env("LLM_PRESENCE_PENALTY", 1.5)
 LLM_REASONING_EFFORT = os.getenv("LLM_REASONING_EFFORT", "none").strip() or "none"
+LLM_THINKING_EFFORT = os.getenv("LLM_THINKING_EFFORT", "high").strip() or "high"
 LLM_SHOW_REASONING = _bool_env("LLM_SHOW_REASONING", False)
 LLM_MAX_TOKENS = _int_env_optional("LLM_MAX_TOKENS")
 IMG_TOKEN_COST_DEFAULT = _int_env("IMG_TOKEN_COST_DEFAULT", 2048)
@@ -95,3 +96,25 @@ def _ollama_base_url() -> str:
     If /v1 isn't present, returns the URL without trailing slash.
     """
     return LLM_BASE_URL.rstrip("/").split("/v1")[0]
+
+
+def reasoning_effort_for_turn(thinking_mode_enabled: bool) -> str:
+    """
+    Return reasoning effort for the current turn.
+
+    Thinking mode uses a separate operator-tunable effort value so deployments can
+    adjust quality/latency tradeoffs without source edits.
+    """
+    return LLM_THINKING_EFFORT if thinking_mode_enabled else LLM_REASONING_EFFORT
+
+
+def max_tokens_for_turn(thinking_mode_enabled: bool) -> Optional[int]:
+    """
+    Return max_tokens to send for the current turn.
+
+    In thinking mode we omit max_tokens to avoid budget starvation where hidden
+    reasoning consumes most of a small completion cap and truncates visible output.
+    """
+    if thinking_mode_enabled:
+        return None
+    return LLM_MAX_TOKENS

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -18,14 +18,14 @@ from ephemeral.config import (
     DEBUG_MODE,
     ENABLE_TOKEN_BUDGETING,
     LLM_BASE_URL,
-    LLM_MAX_TOKENS,
     LLM_MODEL_NAME,
     LLM_OUTPUT_RESERVE_TOKENS,
     LLM_PRESENCE_PENALTY,
-    LLM_REASONING_EFFORT,
     LLM_SHOW_REASONING,
     LLM_TEMPERATURE,
     LLM_TOP_P,
+    max_tokens_for_turn,
+    reasoning_effort_for_turn,
 )
 from ephemeral.export import (
     build_conversation_html,
@@ -126,8 +126,8 @@ def timestamp_local() -> str:
 tmpl_path = pathlib.Path(__file__).parent / "system_prompt_template.md"
 if tmpl_path.exists():
     # Default system template is model-agnostic and omits <|think|>.
-    # Request defaults also set reasoning_effort to "none"; keep the think-block
-    # filter as defense-in-depth even when reasoning visibility is toggled.
+    # Request defaults keep reasoning disabled unless Thinking Mode is enabled.
+    # Keep think-block filtering as defense-in-depth even when reasoning visibility is toggled.
     SYSTEM_TMPL = string.Template(tmpl_path.read_text(encoding="utf-8"))
 else:
     SYSTEM_TMPL = string.Template(
@@ -221,6 +221,9 @@ with st.sidebar:
 
     if DEBUG_MODE:
         with st.expander("System status", expanded=False):
+            dbg_thinking_mode = bool(st.session_state.get("thinking_mode_enabled", False))
+            dbg_effective_reasoning_effort = reasoning_effort_for_turn(dbg_thinking_mode)
+            dbg_effective_max_tokens = max_tokens_for_turn(dbg_thinking_mode)
             dbg_model_ctx = get_model_ctx()
             dbg_effective_ctx = dbg_model_ctx if dbg_model_ctx else 32768
             dbg_usable_ctx = int(dbg_effective_ctx * 0.95)
@@ -237,11 +240,12 @@ with st.sidebar:
             st.caption(
                 "Request settings: "
                 f"temperature={LLM_TEMPERATURE}, top_p={LLM_TOP_P}, "
-                f"presence_penalty={LLM_PRESENCE_PENALTY}, reasoning_effort={LLM_REASONING_EFFORT!r}"
+                f"presence_penalty={LLM_PRESENCE_PENALTY}, "
+                f"reasoning_effort={dbg_effective_reasoning_effort!r}"
             )
             st.caption(
                 "LLM_MAX_TOKENS: "
-                + (str(LLM_MAX_TOKENS) if LLM_MAX_TOKENS is not None else "not set (max_tokens omitted)")
+                + (str(dbg_effective_max_tokens) if dbg_effective_max_tokens is not None else "not set (max_tokens omitted)")
             )
 
             tok_state = st.session_state.get("tokenizer_available")
@@ -383,6 +387,16 @@ if HAS_DEVICE_DETECTION and device and device.is_mobile:
 
 
 # ── Chat input ───────────────────────────────────────────────────
+thinking_mode = st.toggle(
+    "Thinking Mode",
+    value=False,
+    help=(
+        "Improves quality on complex coding and reasoning tasks, "
+        "but responses are typically much slower (often around 4×)."
+    ),
+    key="thinking_mode_enabled",
+)
+
 prompt_in = st.chat_input(
     "Ask a question or attach files...",
     accept_file="multiple",
@@ -685,10 +699,11 @@ if prompt_in is not None:
                     "temperature": LLM_TEMPERATURE,
                     "top_p": LLM_TOP_P,
                     "presence_penalty": LLM_PRESENCE_PENALTY,
-                    "extra_body": {"reasoning_effort": LLM_REASONING_EFFORT},
+                    "extra_body": {"reasoning_effort": reasoning_effort_for_turn(thinking_mode)},
                 }
-                if LLM_MAX_TOKENS is not None:
-                    request_kwargs["max_tokens"] = LLM_MAX_TOKENS
+                turn_max_tokens = max_tokens_for_turn(thinking_mode)
+                if turn_max_tokens is not None:
+                    request_kwargs["max_tokens"] = turn_max_tokens
 
                 # Try include_usage if supported, fall back otherwise.
                 try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 from ephemeral import config
+import pytest
 
 
 def test_float_env_valid_invalid_blank_missing(monkeypatch):
@@ -75,3 +76,30 @@ def test_ollama_base_url_variants(monkeypatch):
 
     monkeypatch.setattr(config, "LLM_BASE_URL", "http://ollama:11434/")
     assert config._ollama_base_url() == "http://ollama:11434"
+
+
+@pytest.mark.parametrize(
+    ("thinking_mode_enabled", "expected_effort"),
+    [
+        (False, "none"),
+        (True, "high"),
+    ],
+)
+def test_reasoning_effort_for_turn(monkeypatch, thinking_mode_enabled, expected_effort):
+    monkeypatch.setattr(config, "LLM_REASONING_EFFORT", "none")
+    monkeypatch.setattr(config, "LLM_THINKING_EFFORT", "high")
+    assert config.reasoning_effort_for_turn(thinking_mode_enabled) == expected_effort
+
+
+@pytest.mark.parametrize(
+    ("thinking_mode_enabled", "configured_max_tokens", "expected_max_tokens"),
+    [
+        (False, 2048, 2048),
+        (False, None, None),
+        (True, 2048, None),
+        (True, None, None),
+    ],
+)
+def test_max_tokens_for_turn(monkeypatch, thinking_mode_enabled, configured_max_tokens, expected_max_tokens):
+    monkeypatch.setattr(config, "LLM_MAX_TOKENS", configured_max_tokens)
+    assert config.max_tokens_for_turn(thinking_mode_enabled) == expected_max_tokens


### PR DESCRIPTION
### Motivation
- Provide a toggleable "Thinking Mode" that lets deployments tune a separate reasoning effort and avoid hidden-reasoning consuming a small `max_tokens` budget.
- Allow operator-configurable default for thinking-mode effort via an environment variable so quality/latency tradeoffs can be adjusted without code edits.

### Description
- Add `LLM_THINKING_EFFORT` env var with default `"high"` and two helpers `reasoning_effort_for_turn` and `max_tokens_for_turn` in `ephemeral/config.py` to return per-turn values based on thinking mode state.
- Wire the new helpers into the UI and runtime: add a `Thinking Mode` `st.toggle` stored as `thinking_mode_enabled`, show the effective reasoning effort and `max_tokens` in the debug panel, pass `reasoning_effort` in `extra_body` to the LLM client, and omit `max_tokens` when thinking mode is enabled.
- Keep think-block filtering comment updated and preserve defensive filtering of hidden reasoning blocks.
- Add unit tests in `tests/test_config.py` to validate `reasoning_effort_for_turn` and `max_tokens_for_turn`, and add the `pytest` import used by the new parametrized tests.

### Testing
- Ran the test module `tests/test_config.py` including new parametrized tests for `reasoning_effort_for_turn` and `max_tokens_for_turn`, and they passed.
- Executed the repository test suite (`pytest`) to ensure no regressions from the changes, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef95d6652483288a784ce465467ce0)