### PR TITLE
Move Thinking Mode toggle closer to chat composer

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -387,6 +387,13 @@ if HAS_DEVICE_DETECTION and device and device.is_mobile:
 
 
 # ── Chat input ───────────────────────────────────────────────────
+prompt_in = st.chat_input(
+    "Ask a question or attach files...",
+    accept_file="multiple",
+    max_upload_size=50,
+    key="main_chat",
+)
+
 thinking_mode = st.toggle(
     "Thinking Mode",
     value=False,
@@ -395,13 +402,6 @@ thinking_mode = st.toggle(
         "but responses are typically much slower (often around 4×)."
     ),
     key="thinking_mode_enabled",
-)
-
-prompt_in = st.chat_input(
-    "Ask a question or attach files...",
-    accept_file="multiple",
-    max_upload_size=50,
-    key="main_chat",
 )
 
 if prompt_in is not None:


### PR DESCRIPTION
### Motivation
- Place the Thinking Mode toggle nearer the chat composer so it is more discoverable and contextually located where users type or attach files.

### Description
- Moved the `Thinking Mode` `st.toggle` block to render immediately after the `st.chat_input(...)` call in `ephemeral_app.py`, keeping the existing state key `thinking_mode_enabled` and behavior unchanged.

### Testing
- Ran `python -m pytest -q` and `pytest -q`, both completed successfully with 48 tests passing; `python -m py_compile ephemeral_app.py ephemeral/*.py` succeeded; `ruff check .` reported no issues; `python scripts/ui_smoke.py` passed and produced screenshots in `artifacts/ui-smoke/` (desktop and mobile).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa0bfa8548328b2150c23c32b2997)