### PR TITLE
Position Thinking Mode toggle below chat composer

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -394,15 +394,16 @@ prompt_in = st.chat_input(
     key="main_chat",
 )
 
-thinking_mode = st.toggle(
-    "Thinking Mode",
-    value=False,
-    help=(
-        "Improves quality on complex coding and reasoning tasks, "
-        "but responses are typically much slower (often around 4×)."
-    ),
-    key="thinking_mode_enabled",
-)
+with st.container(key="composer_toggle_row"):
+    thinking_mode = st.toggle(
+        "Thinking Mode",
+        value=False,
+        help=(
+            "Improves quality on complex coding and reasoning tasks, "
+            "but responses are typically much slower (often around 4×)."
+        ),
+        key="thinking_mode_enabled",
+    )
 
 if prompt_in is not None:
     if st.session_state.show_welcome:

--- a/theme.css
+++ b/theme.css
@@ -631,6 +631,12 @@ button[title="View fullscreen"] {
     background: var(--color-bg-main) !important;
 }
 
+/* Streamlit internal test ID: bottom dock container. Offset chat composer up so
+   the Thinking Mode toggle can stay visually attached just below it. */
+[data-testid="stBottom"] {
+    bottom: 2.45rem !important;
+}
+
 /* Streamlit 1.56 internals: unified chat input root surface. */
 [data-testid="stChatInput"] > div {
     border: 1px solid var(--color-border) !important;
@@ -704,6 +710,28 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
     box-shadow: none;
 }
 
+/* Streamlit internal class fragment in 1.56: key-based wrapper for composer-adjacent
+   toggle row. Keep this fixed to the viewport bottom so it tracks chat input dock. */
+[class*="st-key-composer_toggle_row"] {
+    position: fixed;
+    left: calc(var(--sidebar-width) + 1.6rem);
+    right: 2.2rem;
+    bottom: 0.55rem;
+    z-index: 200;
+    pointer-events: none;
+}
+
+[class*="st-key-composer_toggle_row"] [data-testid="stToggle"] {
+    width: fit-content;
+    margin-left: auto;
+    border: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-bg-main) 88%, white 12%);
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    box-shadow: 0 2px 10px rgba(24, 35, 65, 0.08);
+    pointer-events: auto;
+}
+
 @media (max-width: 900px) {
     .main .block-container {
         padding: 1.2rem 1rem 1.2rem 1rem;
@@ -715,5 +743,15 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
 
     .sidebar-brand-title {
         font-size: 1.7rem;
+    }
+
+    [data-testid="stBottom"] {
+        bottom: 2.25rem !important;
+    }
+
+    [class*="st-key-composer_toggle_row"] {
+        left: 0.95rem;
+        right: 0.95rem;
+        bottom: 0.45rem;
     }
 }


### PR DESCRIPTION
### Motivation
- The Thinking Mode toggle was rendering away from the chat composer and needed a stable, visually attached placement directly under the input area for both desktop and mobile states.
- The change must preserve the existing `thinking_mode_enabled` session key, help text, and reasoning behavior while avoiding sidebar regressions.

### Description
- Wrapped the toggle in a keyed Streamlit container (`st.container(key="composer_toggle_row")`) placed immediately after the `st.chat_input` call in `ephemeral_app.py` so there is a stable DOM hook for layout targeting.
- Added CSS in `theme.css` to offset the Streamlit bottom dock, pin the `composer_toggle_row` to the viewport bottom, style the toggle as a composer-adjacent chip, and add responsive offsets for mobile.
- Did not change any reasoning/model defaults, toggle key (`thinking_mode_enabled`), help text, or chat input/upload behavior.

### Testing
- Ran `python -m pytest -q` and `pytest -q` with all tests passing (`48 passed`).
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` and `ruff check .` with no errors.
- Ran the UI smoke script `python scripts/ui_smoke.py`, which passed and produced desktop/mobile screenshots in `artifacts/ui-smoke/after/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa2a66cd88328b12ca04c55a530a2)