### PR TITLE
Fix Thinking Mode toggle interactivity below chat composer

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -718,7 +718,8 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
     right: 2.2rem;
     bottom: 0.55rem;
     z-index: 200;
-    pointer-events: none;
+    /* Keep row interactive so the toggle's help icon can receive hover/focus events. */
+    pointer-events: auto;
 }
 
 [class*="st-key-composer_toggle_row"] [data-testid="stToggle"] {


### PR DESCRIPTION
### Motivation
- Moving the Thinking Mode toggle below the chat composer left its fixed wrapper with `pointer-events: none`, which made the toggle and its help tooltip unresponsive despite correct visual placement.

### Description
- Restore interactivity by updating `theme.css` to change `[class*="st-key-composer_toggle_row"]` from `pointer-events: none` to `pointer-events: auto`, keeping the toggle placement and all Python logic/state (including `key="thinking_mode_enabled"`) unchanged.

### Testing
- Ran `python -m pytest -q` and `pytest -q` (48 tests passed), `python -m py_compile ephemeral_app.py ephemeral/*.py` (succeeded), `ruff check .` (All checks passed), and `python scripts/ui_smoke.py` (UI smoke passed and desktop/mobile screenshots generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa570bd448328b8a1f0db28809491)