### PR TITLE
Reset Thinking Mode on New Chat and stabilize initial composer/toggle layout

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -177,6 +177,19 @@ st.session_state.setdefault("show_welcome", True)
 st.session_state.setdefault("last_token_count", 0)
 st.session_state.setdefault("tokenizer_available", None)
 st.session_state.setdefault("_vision_supported", None)
+st.session_state.setdefault("thinking_mode_enabled", False)
+
+
+def reset_chat_session() -> None:
+    """Reset conversation-scoped state while preserving app/runtime settings."""
+    st.session_state["messages"] = []
+    st.session_state["show_welcome"] = True
+    st.session_state["last_token_count"] = 0
+    st.session_state["tokenizer_available"] = None
+    st.session_state["_vision_supported"] = None
+    # Non-thinking remains the default for each new chat.
+    st.session_state["thinking_mode_enabled"] = False
+    st.session_state.pop("main_chat", None)
 
 # ── Sidebar ───────────────────────────────────────────────────────
 with st.sidebar:
@@ -211,7 +224,7 @@ with st.sidebar:
         st.info("Document reading is temporarily unavailable. You can still chat, but uploads may not be readable.")
 
     if st.button("New Chat", key="sidebar_new", width="stretch"):
-        st.session_state.clear()
+        reset_chat_session()
         st.rerun()
 
     if st.session_state.messages:
@@ -257,6 +270,31 @@ with st.sidebar:
                 st.caption("Token counting: safe estimate mode")
             else:
                 st.caption("Token counting: not checked yet")
+
+# ── Chat input ───────────────────────────────────────────────────
+prompt_in = st.chat_input(
+    "Ask a question or attach files...",
+    accept_file="multiple",
+    max_upload_size=50,
+    key="main_chat",
+)
+
+with st.container(key="composer_toggle_row"):
+    thinking_mode = st.toggle(
+        "Thinking Mode",
+        value=False,
+        help=(
+            "Improves quality on complex coding and reasoning tasks, "
+            "but responses are typically much slower (often around 4×)."
+        ),
+        key="thinking_mode_enabled",
+    )
+
+# Hide the welcome shell in the same run as the first submitted prompt so
+# initial-turn layout and composer spacing remain stable.
+if prompt_in is not None and st.session_state.show_welcome:
+    st.session_state.show_welcome = False
+
 
 # ── Welcome banner ────────────────────────────────────────────────
 if st.session_state.show_welcome:
@@ -382,33 +420,11 @@ for m in st.session_state.messages:
 # ── Mobile convenience button ─────────────────────────────────────
 if HAS_DEVICE_DETECTION and device and device.is_mobile:
     if st.button("🔄 New Chat", key="mobile_new", width="stretch"):
-        st.session_state.clear()
+        reset_chat_session()
         st.rerun()
 
 
-# ── Chat input ───────────────────────────────────────────────────
-prompt_in = st.chat_input(
-    "Ask a question or attach files...",
-    accept_file="multiple",
-    max_upload_size=50,
-    key="main_chat",
-)
-
-with st.container(key="composer_toggle_row"):
-    thinking_mode = st.toggle(
-        "Thinking Mode",
-        value=False,
-        help=(
-            "Improves quality on complex coding and reasoning tasks, "
-            "but responses are typically much slower (often around 4×)."
-        ),
-        key="thinking_mode_enabled",
-    )
-
 if prompt_in is not None:
-    if st.session_state.show_welcome:
-        st.session_state.show_welcome = False
-
     user_text = prompt_in.text if hasattr(prompt_in, "text") else prompt_in
     user_text = (user_text or "").strip()
     files = prompt_in.files if hasattr(prompt_in, "files") else []

--- a/theme.css
+++ b/theme.css
@@ -634,7 +634,7 @@ button[title="View fullscreen"] {
 /* Streamlit internal test ID: bottom dock container. Offset chat composer up so
    the Thinking Mode toggle can stay visually attached just below it. */
 [data-testid="stBottom"] {
-    bottom: 2.45rem !important;
+    bottom: 2rem !important;
 }
 
 /* Streamlit 1.56 internals: unified chat input root surface. */
@@ -644,6 +644,8 @@ button[title="View fullscreen"] {
     background: #ffffff !important;
     box-shadow: 0 5px 16px rgba(41, 56, 91, 0.1);
     padding: 0.3rem 0.42rem !important;
+    width: 100%;
+    max-width: 100%;
 }
 
 [data-testid="stChatInput"] > div:focus-within {
@@ -716,7 +718,7 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
     position: fixed;
     left: calc(var(--sidebar-width) + 1.6rem);
     right: 2.2rem;
-    bottom: 0.55rem;
+    bottom: 0.4rem;
     z-index: 200;
     /* Keep row interactive so the toggle's help icon can receive hover/focus events. */
     pointer-events: auto;
@@ -747,12 +749,12 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
     }
 
     [data-testid="stBottom"] {
-        bottom: 2.25rem !important;
+        bottom: 1.85rem !important;
     }
 
     [class*="st-key-composer_toggle_row"] {
         left: 0.95rem;
         right: 0.95rem;
-        bottom: 0.45rem;
+        bottom: 0.35rem;
     }
 }


### PR DESCRIPTION
### Motivation
- New Chat could leave the Thinking Mode toggle ON, which breaks the intended non-thinking default for new conversations and violates the expected New Chat reset behavior.
- The chat composer/toggle layout exhibited an initial-render jump and awkward wrapping before the first assistant turn due to render-order/state timing and bottom-dock spacing.
- Keep the existing toggle key/label/help text and do not change model or reasoning defaults; only fix reset and layout stability.

### Description
- Added `st.session_state.setdefault("thinking_mode_enabled", False)` and a focused `reset_chat_session()` helper that clears conversation-scoped state while explicitly resetting `thinking_mode_enabled` to `False` and preserving runtime settings.
- Rewired both sidebar and mobile New Chat actions to call `reset_chat_session()` instead of clearing the whole session state to ensure the toggle resets predictably.
- Moved the chat composer (`st.chat_input`) and the Thinking Mode toggle initialization earlier in the render order and hide the welcome shell in the same run as the first submitted prompt to avoid first-turn layout mismatch and rerun-related jumps.
- Tweaked CSS in `theme.css` to tighten bottom offsets and force the chat-input root to full width (`width: 100%; max-width: 100%`) and reduced `composer_toggle_row` bottom offsets for desktop and mobile so the toggle stays visually attached under the composer without excessive vertical gap.

### Testing
- Ran unit/test suite: `python -m pytest -q` and `pytest -q`, both returned all tests passing (`48 passed`).
- Verified Python syntax with `python -m py_compile ephemeral_app.py ephemeral/*.py`, which succeeded.
- Ran linting: `ruff check .`, which passed.
- Executed UI smoke tests: `python scripts/ui_smoke.py`, which passed and produced `artifacts/ui-smoke/home-desktop.png` and `artifacts/ui-smoke/home-mobile.png`.
- No automated tests failed; layout stability and Thinking Mode reset behavior were validated via the UI smoke run and the render-order changes described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaa1e24d08328bff7f0683957158a)