### PR TITLE
Fix first-turn chat bubble width collapse during assistant generation

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -155,7 +155,11 @@ def styled_chat_message(role: str, message_id: str = None):
         "avatar": ":material/account_circle:" if normalized_role == "user" else ":material/assistant:",
     }
     if "width" in inspect.signature(st.chat_message).parameters:
-        chat_kwargs["width"] = "content" if normalized_role == "user" else "stretch"
+        # Keep the chat row as stretch-width for both roles.
+        # User bubble sizing/alignment is handled by CSS. Using "content" for the
+        # user row can trigger transient min-content collapse during first-turn
+        # reruns while the assistant spinner is mounted.
+        chat_kwargs["width"] = "stretch"
 
     with st.container(key=key):
         if normalized_role == "user":

--- a/theme.css
+++ b/theme.css
@@ -409,8 +409,8 @@ button[title="View fullscreen"] {
     justify-content: flex-end;
     align-items: center;
     gap: 0.72rem;
-    width: fit-content;
-    max-width: min(78ch, 86%);
+    width: 100%;
+    max-width: 100%;
     margin-left: auto;
 }
 
@@ -426,8 +426,9 @@ button[title="View fullscreen"] {
     border-right: 4px solid var(--color-asst-msg-border);
     box-shadow: 0 4px 14px rgba(74, 91, 176, 0.09);
     padding: 0.65rem 0.92rem;
-    width: fit-content;
-    max-width: min(72ch, 100%);
+    width: max-content;
+    min-width: 4.25rem;
+    max-width: min(72ch, 86%);
     display: inline-block;
 }
 


### PR DESCRIPTION
### Motivation

- A transient layout regression caused short first-turn user messages to collapse into a narrow/two-line bubble while the assistant was generating, due to a state-dependent min-content shrink during reruns. 
- The change aims to stabilize the composer/chat-row layout during in-flight assistant state without changing Thinking Mode reset behavior or other UI defaults. 

### Description

- Use `st.chat_message(..., width="stretch")` for user rows instead of `width="content"` so the chat row remains full-width during reruns and spinner mounting (file: `ephemeral_app.py`).
- Prevent the user chat row from collapsing by changing the user row CSS from `width: fit-content` to `width: 100%` and `max-width: 100%` (file: `theme.css`).
- Adjust the user bubble content sizing to `width: max-content` with a `min-width: 4.25rem` and bounded `max-width: min(72ch, 86%)` so short inputs like `test` stay on one line while long messages still wrap (file: `theme.css`).
- Preserve existing behavior for Thinking Mode, sidebar controls, chat input, and file upload logic; no changes to model/reasoning defaults or sidebar layout were made.

### Testing

- Ran `python -m pytest -q` which completed successfully (`48 passed`).
- Ran `pytest -q` which completed successfully (`48 passed`).
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` which succeeded with no syntax errors reported.
- Ran `ruff check .` which reported all checks passed.
- Ran UI smoke test `python scripts/ui_smoke.py` which passed and produced desktop and mobile screenshots (`artifacts/ui-smoke/home-desktop.png`, `artifacts/ui-smoke/home-mobile.png`).
- Performed a targeted Playwright capture of the first-turn flow (submit `test`, capture during in-flight generation and after completion) and saved `artifacts/ui-smoke/first-turn-generating.png` and `artifacts/ui-smoke/first-turn-after.png` to validate the regression is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efac6b270083288073184c24f68ee9)