### PR TITLE
Fix bottom composer overlap and Thinking Mode toggle dock alignment

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -41,6 +41,15 @@
     --color-user-avatar-icon: #4a56d8;
     --color-asst-avatar-bg: linear-gradient(160deg, #f2f3ff 0%, #e3e8ff 100%);
     --color-asst-avatar-icon: #4955d6;
+
+    /* Bottom composer + toggle dock geometry */
+    --composer-toggle-row-height: 2.1rem;
+    --composer-toggle-row-bottom: 0.45rem;
+    --composer-toggle-row-gap: 0.3rem;
+    --composer-bottom-offset: calc(
+        var(--composer-toggle-row-bottom) + var(--composer-toggle-row-height) + var(--composer-toggle-row-gap)
+    );
+    --chat-dock-reserve: calc(8.25rem + env(safe-area-inset-bottom));
 }
 
 html,
@@ -100,7 +109,7 @@ section[data-testid="stSidebar"] > div {
 
 .main .block-container {
     max-width: 1180px;
-    padding: 1.6rem 2.2rem 1.5rem 1.6rem;
+    padding: 1.6rem 2.2rem var(--chat-dock-reserve) 1.6rem;
 }
 
 /* Streamlit internal test IDs: keep hover chrome out of custom cards/buttons. */
@@ -630,12 +639,13 @@ button[title="View fullscreen"] {
 [data-testid="stBottom"] > div,
 [data-testid="stBottomBlockContainer"] {
     background: var(--color-bg-main) !important;
+    z-index: 300;
 }
 
 /* Streamlit internal test ID: bottom dock container. Offset chat composer up so
    the Thinking Mode toggle can stay visually attached just below it. */
 [data-testid="stBottom"] {
-    bottom: 2rem !important;
+    bottom: var(--composer-bottom-offset) !important;
 }
 
 /* Streamlit 1.56 internals: unified chat input root surface. */
@@ -717,17 +727,17 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
    toggle row. Keep this fixed to the viewport bottom so it tracks chat input dock. */
 [class*="st-key-composer_toggle_row"] {
     position: fixed;
-    left: calc(var(--sidebar-width) + 1.6rem);
-    right: 2.2rem;
-    bottom: 0.4rem;
-    z-index: 200;
+    left: max(calc(var(--sidebar-width) + 1.6rem), calc(50vw - 590px + 1.6rem));
+    right: max(2.2rem, calc(50vw - 590px + 2.2rem));
+    bottom: var(--composer-toggle-row-bottom);
+    z-index: 301;
     /* Keep row interactive so the toggle's help icon can receive hover/focus events. */
     pointer-events: auto;
 }
 
 [class*="st-key-composer_toggle_row"] [data-testid="stToggle"] {
     width: fit-content;
-    margin-left: auto;
+    margin-left: 0;
     border: 1px solid var(--color-border);
     background: color-mix(in srgb, var(--color-bg-main) 88%, white 12%);
     border-radius: 999px;
@@ -738,7 +748,7 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
 
 @media (max-width: 900px) {
     .main .block-container {
-        padding: 1.2rem 1rem 1.2rem 1rem;
+        padding: 1.2rem 1rem calc(7.85rem + env(safe-area-inset-bottom)) 1rem;
     }
 
     .welcome-shell {
@@ -750,12 +760,12 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
     }
 
     [data-testid="stBottom"] {
-        bottom: 1.85rem !important;
+        bottom: var(--composer-bottom-offset) !important;
     }
 
     [class*="st-key-composer_toggle_row"] {
         left: 0.95rem;
         right: 0.95rem;
-        bottom: 0.35rem;
+        bottom: var(--composer-toggle-row-bottom);
     }
 }


### PR DESCRIPTION
### Motivation

- Prevent chat content from rendering underneath the fixed bottom composer/toggle dock and remove the awkward vertical dead gap between the composer and the Thinking Mode row.
- Align the Thinking Mode row horizontally with the start of the chat input area so the toggle sits under the input/upload start on desktop while preserving mobile behavior.
- Preserve existing behavior for Thinking Mode reset on New Chat, first-turn bubble collapse fixes, sidebar controls, and model/reasoning defaults.

### Description

- Introduced explicit CSS custom properties for the composer/toggle stack geometry (`--composer-toggle-row-height`, `--composer-toggle-row-bottom`, `--composer-toggle-row-gap`, `--composer-bottom-offset`, `--chat-dock-reserve`) in `theme.css` to centralize dock sizing and safe-area offsets.
- Reserved bottom space in the main content container by changing `.main .block-container` bottom padding to `var(--chat-dock-reserve)` so chat content cannot visually leak below the fixed dock.
- Made `stBottom`'s bottom offset derive from `--composer-bottom-offset` and increased z-index on the bottom dock wrapper so the composer/toggle render above scrolling content.
- Adjusted the composer toggle row positioning: use a desktop-friendly `left`/`right` expression to align with the chat input start and set `margin-left: 0` to left-align the toggle; preserved mobile overrides in the media query.

### Testing

- Ran unit tests with `python -m pytest -q` and `pytest -q` which both passed (`48 passed`).
- Verified Python syntax with `python -m py_compile ephemeral_app.py ephemeral/*.py` which completed successfully.
- Ran linting with `ruff check .` which passed with no issues.
- Executed the UI smoke test `python scripts/ui_smoke.py` which passed and produced desktop and mobile screenshots (`artifacts/ui-smoke/home-desktop.png`, `artifacts/ui-smoke/home-mobile.png`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb03e0e748328a3c9b89720ff58a0)