### PR TITLE
Anchor Thinking Mode in Streamlit native bottom dock to fix chat composer drift

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -283,16 +283,20 @@ prompt_in = st.chat_input(
     key="main_chat",
 )
 
-with st.container(key="composer_toggle_row"):
-    thinking_mode = st.toggle(
-        "Thinking Mode",
-        value=False,
-        help=(
-            "Improves quality on complex coding and reasoning tasks, "
-            "but responses are typically much slower (often around 4×)."
-        ),
-        key="thinking_mode_enabled",
-    )
+# Streamlit internal API note (1.56): st._bottom draws into the same native
+# bottom dock used by st.chat_input. Keeping the toggle in this dock avoids
+# viewport-fixed overlays that can interfere with chat streaming layout.
+with st._bottom:
+    with st.container(key="composer_toggle_row"):
+        thinking_mode = st.toggle(
+            "Thinking Mode",
+            value=False,
+            help=(
+                "Improves quality on complex coding and reasoning tasks, "
+                "but responses are typically much slower (often around 4×)."
+            ),
+            key="thinking_mode_enabled",
+        )
 
 # Hide the welcome shell in the same run as the first submitted prompt so
 # initial-turn layout and composer spacing remain stable.

--- a/theme.css
+++ b/theme.css
@@ -44,12 +44,9 @@
 
     /* Bottom composer + toggle dock geometry */
     --composer-toggle-row-height: 2.1rem;
-    --composer-toggle-row-bottom: 0.45rem;
-    --composer-toggle-row-gap: 0.3rem;
-    --composer-bottom-offset: calc(
-        var(--composer-toggle-row-bottom) + var(--composer-toggle-row-height) + var(--composer-toggle-row-gap)
-    );
-    --chat-dock-reserve: calc(8.25rem + env(safe-area-inset-bottom));
+    --composer-toggle-row-gap: 0.35rem;
+    --composer-toggle-inline-start: 2.85rem;
+    --chat-dock-reserve: calc(8.15rem + env(safe-area-inset-bottom));
 }
 
 html,
@@ -642,12 +639,6 @@ button[title="View fullscreen"] {
     z-index: 300;
 }
 
-/* Streamlit internal test ID: bottom dock container. Offset chat composer up so
-   the Thinking Mode toggle can stay visually attached just below it. */
-[data-testid="stBottom"] {
-    bottom: var(--composer-bottom-offset) !important;
-}
-
 /* Streamlit 1.56 internals: unified chat input root surface. */
 [data-testid="stChatInput"] > div {
     border: 1px solid var(--color-border) !important;
@@ -723,21 +714,20 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
     box-shadow: none;
 }
 
-/* Streamlit internal class fragment in 1.56: key-based wrapper for composer-adjacent
-   toggle row. Keep this fixed to the viewport bottom so it tracks chat input dock. */
+/* Streamlit internal class fragment in 1.56: key-based wrapper for the
+   Thinking Mode row that now lives in st._bottom. Keep this in normal flow so
+   Streamlit's native bottom dock owns height/scroll anchoring during reruns. */
 [class*="st-key-composer_toggle_row"] {
-    position: fixed;
-    left: max(calc(var(--sidebar-width) + 1.6rem), calc(50vw - 590px + 1.6rem));
-    right: max(2.2rem, calc(50vw - 590px + 2.2rem));
-    bottom: var(--composer-toggle-row-bottom);
+    position: relative;
     z-index: 301;
-    /* Keep row interactive so the toggle's help icon can receive hover/focus events. */
+    margin-top: var(--composer-toggle-row-gap);
+    padding: 0 0 env(safe-area-inset-bottom) 0;
     pointer-events: auto;
 }
 
 [class*="st-key-composer_toggle_row"] [data-testid="stToggle"] {
     width: fit-content;
-    margin-left: 0;
+    margin-left: var(--composer-toggle-inline-start);
     border: 1px solid var(--color-border);
     background: color-mix(in srgb, var(--color-bg-main) 88%, white 12%);
     border-radius: 999px;
@@ -759,13 +749,11 @@ button[data-testid="stChatInputSubmitButton"]:disabled {
         font-size: 1.7rem;
     }
 
-    [data-testid="stBottom"] {
-        bottom: var(--composer-bottom-offset) !important;
+    [class*="st-key-composer_toggle_row"] {
+        margin-top: 0.32rem;
     }
 
-    [class*="st-key-composer_toggle_row"] {
-        left: 0.95rem;
-        right: 0.95rem;
-        bottom: var(--composer-toggle-row-bottom);
+    [class*="st-key-composer_toggle_row"] [data-testid="stToggle"] {
+        margin-left: 2.7rem;
     }
 }


### PR DESCRIPTION
### Motivation
- Fix a Streamlit 1.56 chat UI regression where dual anchoring (manually offsetting Streamlit's bottom dock while rendering a viewport-fixed Thinking Mode row) caused assistant content to leak behind the composer and long-stream drift. 
- Keep the previously-merged first-turn collapse fix and the New Chat thinking-mode reset behavior unchanged. 
- Make the minimal layout change needed so the composer and toggle share Streamlit's native bottom flow and preserve existing labels/keys/help text.

### Description
- Moved the Thinking Mode row into Streamlit's native bottom container by wrapping the `composer_toggle_row` usage in `with st._bottom:` in `ephemeral_app.py`, preserving toggle key, label, help, and default/reset semantics. 
- Removed CSS that offset `[data-testid="stBottom"]` upward and converted the toggle row from a viewport-fixed overlay to normal bottom-dock flow in `theme.css`. 
- Introduced a small left-inset variable (`--composer-toggle-inline-start`) and adjusted spacing variables so the toggle aligns under the chat input start on desktop and mobile, while keeping Streamlit-internal selector comments to signal 1.56 brittleness. 
- Preserved branding, :root custom-property architecture, and no new dependencies.

### Testing
- Ran unit tests with `python -m pytest -q` and `pytest -q`, yielding `48 passed` and no failures. 
- Verified syntax with `python -m py_compile ephemeral_app.py ephemeral/*.py` which completed without errors. 
- Ran linter with `ruff check .` and received `All checks passed!`. 
- Executed the UI smoke script `python scripts/ui_smoke.py` which passed and produced `artifacts/ui-smoke/home-desktop.png` and `artifacts/ui-smoke/home-mobile.png`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb5ac4c6c83288a9a99875d1fea0e)