### PR TITLE
Make branding, prompts, and upload limits config-driven

### DIFF
--- a/ephemeral/__init__.py
+++ b/ephemeral/__init__.py
@@ -1,1 +1,1 @@
-"""EphemerAl import-safe utility modules."""
+"""Import-safe utility modules for the local assistant app."""

--- a/ephemeral/config.py
+++ b/ephemeral/config.py
@@ -21,12 +21,6 @@ DEBUG_MODE = os.getenv("EPHEMERAL_DEBUG", "0").strip().lower() in {"1", "true", 
 # Feature toggle (operator-only)
 ENABLE_TOKEN_BUDGETING = os.getenv("ENABLE_TOKEN_BUDGETING", "1").strip().lower() not in {"0", "false", "no"}
 
-LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
-LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "ephemeral-default")
-TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")
-LLM_SUPPORTS_VISION = os.getenv("LLM_SUPPORTS_VISION")
-
-
 def _float_env(name: str, default: float) -> float:
     """Parse a float env var with safe fallback on missing/blank/invalid values."""
     raw = os.getenv(name)
@@ -74,6 +68,23 @@ def _bool_env(name: str, default: bool = False) -> bool:
         return False
     return default
 
+
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "ephemeral-default")
+TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")
+LLM_SUPPORTS_VISION = os.getenv("LLM_SUPPORTS_VISION")
+
+APP_DISPLAY_NAME = os.getenv("APP_DISPLAY_NAME", "EphemerAI")
+APP_SUBTITLE = os.getenv("APP_SUBTITLE", "Private AI Assistant")
+APP_WELCOME_SUBTITLE = os.getenv(
+    "APP_WELCOME_SUBTITLE",
+    "Your private workspace for focused, ephemeral conversations.",
+)
+APP_LOGO_PATH = os.getenv("APP_LOGO_PATH", "static/ephemeral_logo.png")
+APP_EXPORT_TITLE = os.getenv("APP_EXPORT_TITLE", f"{APP_DISPLAY_NAME} Conversation")
+SYSTEM_PROMPT_PATH = os.getenv("SYSTEM_PROMPT_PATH", "system_prompt_template.md")
+MAX_UPLOAD_MB = _int_env("MAX_UPLOAD_MB", 50)
+DEFAULT_UPLOAD_PROMPT = os.getenv("DEFAULT_UPLOAD_PROMPT", "Please analyze the uploaded files.")
 
 TIKA_TIMEOUT_S = _int_env("TIKA_TIMEOUT_S", 15)
 LLM_CONTEXT_TOKENS = _int_env_optional("LLM_CONTEXT_TOKENS")

--- a/ephemeral/export.py
+++ b/ephemeral/export.py
@@ -2,7 +2,7 @@ import re
 from html import escape as html_escape
 from typing import List, Tuple, Union
 
-from ephemeral.config import CONTEXT_PREFIX
+from ephemeral.config import APP_EXPORT_TITLE, CONTEXT_PREFIX
 
 
 def build_message_text(messages: List[dict]) -> str:
@@ -96,7 +96,7 @@ def _extract_export_info(content: Union[str, list]) -> Tuple[List[str], List[str
 
 def build_conversation_markdown(messages: List[dict]) -> str:
     """Build a Markdown transcript used as plain-text clipboard fallback."""
-    lines: List[str] = ["# EphemerAl Conversation", ""]
+    lines: List[str] = [f"# {APP_EXPORT_TITLE}", ""]
 
     for msg in messages:
         lines.extend(_build_message_markdown_lines(msg))
@@ -230,7 +230,7 @@ def _md_to_html_basic(md: str) -> str:
 
 def build_conversation_html(messages: List[dict]) -> str:
     """Rich transcript as HTML for clipboard copy."""
-    chunks: List[str] = ["<div>", "<p><strong>EphemerAl Conversation</strong></p>"]
+    chunks: List[str] = ["<div>", f"<p><strong>{html_escape(APP_EXPORT_TITLE)}</strong></p>"]
 
     for msg in messages:
         chunks.append(build_message_html(msg))

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -13,7 +13,11 @@ from typing import Union, List
 import streamlit as st
 import pytz
 from ephemeral.config import (
+    APP_DISPLAY_NAME,
+    APP_LOGO_PATH,
+    APP_SUBTITLE,
     APP_VERSION,
+    APP_WELCOME_SUBTITLE,
     CONTEXT_PREFIX,
     DEBUG_MODE,
     ENABLE_TOKEN_BUDGETING,
@@ -24,6 +28,9 @@ from ephemeral.config import (
     LLM_SHOW_REASONING,
     LLM_TEMPERATURE,
     LLM_TOP_P,
+    MAX_UPLOAD_MB,
+    DEFAULT_UPLOAD_PROMPT,
+    SYSTEM_PROMPT_PATH,
     max_tokens_for_turn,
     reasoning_effort_for_turn,
 )
@@ -54,13 +61,13 @@ from ephemeral.llm_client import (
 
 # ── Page config ───────────────────────────────────────────────────
 st.set_page_config(
-    page_title="EphemerAI",
+    page_title=APP_DISPLAY_NAME,
     layout="wide",
     initial_sidebar_state=304,
     menu_items={
         "Get help": None,
         "Report a Bug": None,
-        "About": "EphemerAI is a privacy-focused document chat assistant.",
+        "About": f"{APP_DISPLAY_NAME} is a privacy-focused document chat assistant.",
     },
 )
 
@@ -83,8 +90,7 @@ except ImportError:
     device = None  # type: ignore
 
 # ── Backend configuration ─────────────────────────────────────────
-DEFAULT_UPLOAD_PROMPT = os.getenv("DEFAULT_UPLOAD_PROMPT", "Please analyze the uploaded files.")
-MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+MAX_UPLOAD_BYTES = MAX_UPLOAD_MB * 1024 * 1024
 
 
 def get_local_timezone() -> tzinfo:
@@ -123,13 +129,17 @@ def timestamp_local() -> str:
     return now.strftime(fmt)
 
 
-tmpl_path = pathlib.Path(__file__).parent / "system_prompt_template.md"
+tmpl_path = pathlib.Path(SYSTEM_PROMPT_PATH)
+if not tmpl_path.is_absolute():
+    tmpl_path = pathlib.Path(__file__).resolve().parent / tmpl_path
 if tmpl_path.exists():
     # Default system template is model-agnostic and omits <|think|>.
     # Request defaults keep reasoning disabled unless Thinking Mode is enabled.
     # Keep think-block filtering as defense-in-depth even when reasoning visibility is toggled.
     SYSTEM_TMPL = string.Template(tmpl_path.read_text(encoding="utf-8"))
 else:
+    if DEBUG_MODE:
+        st.warning(f"System prompt template not found at {tmpl_path}. Using built-in fallback prompt.")
     SYSTEM_TMPL = string.Template(
         "You are a helpful AI assistant. The current local time is ${current_time_local}. "
         "Answer concisely and accurately based on the context provided."
@@ -137,7 +147,7 @@ else:
 
 
 @st.cache_data(show_spinner=False)
-def _load_logo_b64(path: str = "static/ephemeral_logo.png") -> str:
+def _load_logo_b64(path: str = APP_LOGO_PATH) -> str:
     """Read and base64-encode the logo once, cached across reruns."""
     logo_path = pathlib.Path(path)
     if logo_path.exists():
@@ -197,25 +207,25 @@ def reset_chat_session() -> None:
 
 # ── Sidebar ───────────────────────────────────────────────────────
 with st.sidebar:
-    logo_b64 = _load_logo_b64()
+    logo_b64 = _load_logo_b64(APP_LOGO_PATH)
     if logo_b64:
         st.markdown(
             f"""
             <div class="sidebar-brand">
-                <img src="data:image/png;base64,{logo_b64}" alt="EphemerAI logo" class="sidebar-brand-logo">
-                <div class="sidebar-brand-title">EphemerAI</div>
-                <div class="sidebar-brand-subtitle">Private AI Assistant</div>
+                <img src="data:image/png;base64,{logo_b64}" alt="{APP_DISPLAY_NAME} logo" class="sidebar-brand-logo">
+                <div class="sidebar-brand-title">{APP_DISPLAY_NAME}</div>
+                <div class="sidebar-brand-subtitle">{APP_SUBTITLE}</div>
             </div>
             """,
             unsafe_allow_html=True,
         )
     else:
         st.markdown(
-            """
+            f"""
             <div class="sidebar-brand">
                 <div class="sidebar-brand-fallback">E</div>
-                <div class="sidebar-brand-title">EphemerAI</div>
-                <div class="sidebar-brand-subtitle">Private AI Assistant</div>
+                <div class="sidebar-brand-title">{APP_DISPLAY_NAME}</div>
+                <div class="sidebar-brand-subtitle">{APP_SUBTITLE}</div>
             </div>
             """,
             unsafe_allow_html=True,
@@ -279,7 +289,7 @@ with st.sidebar:
 prompt_in = st.chat_input(
     "Ask a question or attach files...",
     accept_file="multiple",
-    max_upload_size=50,
+    max_upload_size=MAX_UPLOAD_MB,
     key="main_chat",
 )
 
@@ -307,10 +317,10 @@ if prompt_in is not None and st.session_state.show_welcome:
 # ── Welcome banner ────────────────────────────────────────────────
 if st.session_state.show_welcome:
     st.markdown(
-        """
+        f"""
         <section class="welcome-shell" aria-label="Welcome">
-          <h1 class="welcome-heading">Welcome to <span class="welcome-heading-brand">EphemerAI</span></h1>
-          <p class="welcome-subtitle">Your private workspace for focused, ephemeral conversations.</p>
+          <h1 class="welcome-heading">Welcome to <span class="welcome-heading-brand">{APP_DISPLAY_NAME}</span></h1>
+          <p class="welcome-subtitle">{APP_WELCOME_SUBTITLE}</p>
 
           <div class="welcome-card">
             <div class="welcome-features" role="list">
@@ -493,7 +503,7 @@ if prompt_in is not None:
         if file_size > MAX_UPLOAD_BYTES:
             st.error(
                 f"{f.name} is too large ({file_size / (1024 * 1024):.1f} MB). "
-                "The maximum file size is 50 MB."
+                f"The maximum file size is {MAX_UPLOAD_MB} MB."
             )
             continue
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import importlib
+
 from ephemeral import config
 import pytest
 
@@ -103,3 +105,41 @@ def test_reasoning_effort_for_turn(monkeypatch, thinking_mode_enabled, expected_
 def test_max_tokens_for_turn(monkeypatch, thinking_mode_enabled, configured_max_tokens, expected_max_tokens):
     monkeypatch.setattr(config, "LLM_MAX_TOKENS", configured_max_tokens)
     assert config.max_tokens_for_turn(thinking_mode_enabled) == expected_max_tokens
+
+
+def test_branding_and_prompt_defaults(monkeypatch):
+    for key in [
+        "APP_DISPLAY_NAME",
+        "APP_SUBTITLE",
+        "APP_WELCOME_SUBTITLE",
+        "APP_LOGO_PATH",
+        "APP_EXPORT_TITLE",
+        "SYSTEM_PROMPT_PATH",
+        "MAX_UPLOAD_MB",
+        "DEFAULT_UPLOAD_PROMPT",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    cfg = importlib.reload(config)
+
+    assert cfg.APP_DISPLAY_NAME == "EphemerAI"
+    assert cfg.APP_SUBTITLE == "Private AI Assistant"
+    assert cfg.APP_WELCOME_SUBTITLE == "Your private workspace for focused, ephemeral conversations."
+    assert cfg.APP_LOGO_PATH == "static/ephemeral_logo.png"
+    assert cfg.APP_EXPORT_TITLE == "EphemerAI Conversation"
+    assert cfg.SYSTEM_PROMPT_PATH == "system_prompt_template.md"
+    assert cfg.MAX_UPLOAD_MB == 50
+    assert cfg.DEFAULT_UPLOAD_PROMPT == "Please analyze the uploaded files."
+
+
+def test_max_upload_mb_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("MAX_UPLOAD_MB", "0")
+    cfg = importlib.reload(config)
+    assert cfg.MAX_UPLOAD_MB == 50
+
+    monkeypatch.setenv("MAX_UPLOAD_MB", "75")
+    cfg = importlib.reload(config)
+    assert cfg.MAX_UPLOAD_MB == 75
+
+    monkeypatch.delenv("MAX_UPLOAD_MB", raising=False)
+    importlib.reload(config)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,3 +1,5 @@
+import importlib
+
 from ephemeral.export import (
     _extract_export_info,
     _md_to_html_basic,
@@ -53,7 +55,7 @@ def test_markdown_and_html_build_and_escape():
     ]
 
     md = build_conversation_markdown(messages)
-    assert "# EphemerAl Conversation" in md
+    assert md.startswith("# EphemerAI Conversation\n")
     assert "**User**" in md
     assert "Attachments:" in md
     assert "- 📄 doc1.pdf" in md
@@ -128,3 +130,21 @@ def test_md_to_html_basic_preserves_nested_bullets():
     assert "<li>Parent\n<ul>" in html
     assert "<li>Child A\n</li>" in html
     assert "<li>Child B\n</li>" in html
+
+
+def test_export_title_env_override(monkeypatch):
+    monkeypatch.setenv("APP_EXPORT_TITLE", "Custom Export Title")
+    import ephemeral.config as config_mod
+    import ephemeral.export as export_mod
+
+    importlib.reload(config_mod)
+    export_mod = importlib.reload(export_mod)
+
+    md = export_mod.build_conversation_markdown([])
+    html = export_mod.build_conversation_html([])
+    assert md.startswith("# Custom Export Title\n")
+    assert "<strong>Custom Export Title</strong>" in html
+
+    monkeypatch.delenv("APP_EXPORT_TITLE", raising=False)
+    importlib.reload(config_mod)
+    importlib.reload(export_mod)

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -100,7 +100,7 @@ def test_sidebar_logo_encoding_is_cached():
     app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
     assert "@st.cache_data(show_spinner=False)" in app_text
     assert "def _load_logo_b64(" in app_text
-    assert "logo_b64 = _load_logo_b64()" in app_text
+    assert "logo_b64 = _load_logo_b64(APP_LOGO_PATH)" in app_text
 
 
 def test_clipboard_module_is_used():


### PR DESCRIPTION
### Motivation
- Allow deployers to customize user-facing branding and defaults (display name, subtitles, logo, export title, system prompt path, upload limits and default upload prompt) via environment variables instead of editing Python source.
- Preserve import-safety for utility modules and keep Docker service-name defaults intact to avoid Compose breakage.

### Description
- Added env-backed settings in `ephemeral/config.py`: `APP_DISPLAY_NAME`, `APP_SUBTITLE`, `APP_WELCOME_SUBTITLE`, `APP_LOGO_PATH`, `APP_EXPORT_TITLE`, `SYSTEM_PROMPT_PATH`, `MAX_UPLOAD_MB` (parsed via `_int_env`), and `DEFAULT_UPLOAD_PROMPT` with safe defaults and no change to Docker service-name defaults.
- Updated `ephemeral_app.py` to consume the new config values for `page_title`, About text, sidebar title/subtitle, logo alt text and loading, welcome heading/subtitle, `max_upload_size`/size checks (now using `MAX_UPLOAD_MB`), default upload prompt, and system prompt loading using `SYSTEM_PROMPT_PATH` with relative-path resolution from the app root and a debug-only fallback warning when the file is missing.
- Updated `ephemeral/export.py` to use `APP_EXPORT_TITLE` for Markdown and HTML export headers while keeping the module import-safe and avoiding Streamlit dependencies.
- Replaced the package docstring in `ephemeral/__init__.py` with a generic import-safe description.
- Updated tests to assert config-backed defaults and to add an environment-override test for `APP_EXPORT_TITLE`, plus tests for `APP_DISPLAY_NAME`, `DEFAULT_UPLOAD_PROMPT`, `MAX_UPLOAD_MB`, and `SYSTEM_PROMPT_PATH`; updated a static contract expecting the `_load_logo_b64` call to use `APP_LOGO_PATH`.

### Testing
- Ran `python -m pytest -q` and all tests passed (`54 passed`).
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` and compilation succeeded.
- Ran `ruff check .` and it succeeded in this environment.
- Ran the repo search for lingering hard-coded branding/prompt markers and verified the expected `DEFAULT_UPLOAD_PROMPT`/config entry is now present in `ephemeral/config.py` and other matches were intentional and covered by tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f296b698988328b19e4b22e4677504)