### PR TITLE
Make sidebar logo loader MIME-aware

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -8,7 +8,7 @@ import inspect
 from contextlib import contextmanager
 from datetime import datetime, tzinfo
 from html import escape as html_escape
-from typing import Union, List
+from typing import Union, List, NamedTuple
 
 import streamlit as st
 import pytz
@@ -146,13 +146,41 @@ else:
     )
 
 
+class LogoData(NamedTuple):
+    mime_type: str
+    b64: str
+
+
+def _logo_mime_type(path: pathlib.Path) -> str:
+    """Infer a supported logo MIME type from file extension."""
+    ext = path.suffix.lower()
+    mime_types = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".svg": "image/svg+xml",
+    }
+    return mime_types.get(ext, "")
+
+
 @st.cache_data(show_spinner=False)
-def _load_logo_b64(path: str = APP_LOGO_PATH) -> str:
-    """Read and base64-encode the logo once, cached across reruns."""
+def _load_logo_data(path: str = APP_LOGO_PATH) -> LogoData:
+    """Read and base64-encode a supported logo once, cached across reruns."""
+    if not path:
+        return LogoData("", "")
+
     logo_path = pathlib.Path(path)
-    if logo_path.exists():
-        return base64.b64encode(logo_path.read_bytes()).decode("ascii")
-    return ""
+    if not logo_path.exists():
+        return LogoData("", "")
+
+    mime_type = _logo_mime_type(logo_path)
+    if not mime_type:
+        if DEBUG_MODE:
+            logging.getLogger(__name__).debug("Unsupported logo extension for %s", logo_path)
+        return LogoData("", "")
+
+    return LogoData(mime_type, base64.b64encode(logo_path.read_bytes()).decode("ascii"))
 
 
 # ── Chat message wrapper for CSS styling ──────────────────────────
@@ -207,12 +235,12 @@ def reset_chat_session() -> None:
 
 # ── Sidebar ───────────────────────────────────────────────────────
 with st.sidebar:
-    logo_b64 = _load_logo_b64(APP_LOGO_PATH)
-    if logo_b64:
+    logo = _load_logo_data(APP_LOGO_PATH)
+    if logo.b64:
         st.markdown(
             f"""
             <div class="sidebar-brand">
-                <img src="data:image/png;base64,{logo_b64}" alt="{APP_DISPLAY_NAME} logo" class="sidebar-brand-logo">
+                <img src="data:{logo.mime_type};base64,{logo.b64}" alt="{APP_DISPLAY_NAME} logo" class="sidebar-brand-logo">
                 <div class="sidebar-brand-title">{APP_DISPLAY_NAME}</div>
                 <div class="sidebar-brand-subtitle">{APP_SUBTITLE}</div>
             </div>

--- a/tests/test_logo_mime_contracts.py
+++ b/tests/test_logo_mime_contracts.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_logo_mime_type_map_supports_expected_extensions():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert '".png": "image/png"' in app_text
+    assert '".jpg": "image/jpeg"' in app_text
+    assert '".jpeg": "image/jpeg"' in app_text
+    assert '".webp": "image/webp"' in app_text
+    assert '".svg": "image/svg+xml"' in app_text
+
+
+def test_logo_rendering_uses_display_name_alt_text_and_fallback_branding():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert 'alt="{APP_DISPLAY_NAME} logo"' in app_text
+    assert '<div class="sidebar-brand-title">{APP_DISPLAY_NAME}</div>' in app_text
+    assert '<div class="sidebar-brand-subtitle">{APP_SUBTITLE}</div>' in app_text

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -96,11 +96,12 @@ def test_ghost_doc_cleanup_uses_attachment_metadata_not_marker_text():
     assert 'startswith("\U0001f4c4 *")' not in app_text
 
 
-def test_sidebar_logo_encoding_is_cached():
+def test_sidebar_logo_loading_is_cached_with_mime_aware_data_uri():
     app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
     assert "@st.cache_data(show_spinner=False)" in app_text
-    assert "def _load_logo_b64(" in app_text
-    assert "logo_b64 = _load_logo_b64(APP_LOGO_PATH)" in app_text
+    assert "def _load_logo_data(" in app_text
+    assert "logo = _load_logo_data(APP_LOGO_PATH)" in app_text
+    assert 'data:{logo.mime_type};base64,{logo.b64}' in app_text
 
 
 def test_clipboard_module_is_used():


### PR DESCRIPTION
### Motivation
- Ensure the app uses the configured `APP_LOGO_PATH` with the correct MIME type so logos render correctly for different image formats.
- Replace the untyped/extension-agnostic base64 loader with a small structured result to make data-URI construction explicit and testable.

### Description
- Introduce `LogoData` (`NamedTuple`) and a small `_logo_mime_type` helper that maps `.png`, `.jpg`/`.jpeg`, `.webp`, and `.svg` to their respective MIME types, returning empty string for unsupported extensions.
- Replace `@st.cache_data def _load_logo_b64(...)` with `@st.cache_data def _load_logo_data(...) -> LogoData` which returns `LogoData("", "")` for missing/unsupported logos and base64 data with MIME for supported files.
- Update the sidebar call site to use `logo = _load_logo_data(APP_LOGO_PATH)` and construct the data URI as `data:{logo.mime_type};base64,{logo.b64}`, preserving the alt text derived from `APP_DISPLAY_NAME` and the fallback title/subtitle rendering.
- Update `tests/test_ui_static_contracts.py` to assert the new helper usage and add `tests/test_logo_mime_contracts.py` to verify the extension→MIME mapping and branding/alt-text template strings; the only updated `_load_logo_b64` call site was the sidebar in `ephemeral_app.py` (now using `_load_logo_data`).

### Testing
- Ran `python -m pytest -q` and all tests passed: `56 passed`.
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` with no syntax errors reported.
- Ran `ruff check .` and the linter completed successfully with no new issues.
- Searched for stale patterns with `rg` and confirmed `data:image/png;base64`, `logo_b64 = _load_logo_b64()`, and `alt="EphemerAI logo"` do not remain in the app/tests (no matches).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f298206b448328868daf292e08fc7f)