### PR TITLE
Generalize deployment config via .env.example and Compose defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,93 @@
-# Optional operator overrides (copy to .env and adjust as needed)
-OLLAMA_API_BIND=127.0.0.1
-OLLAMA_MAX_QUEUE=16
+###############################################################################
+# .env.example — Primary deployment configuration surface for EphemerAl
+# Copy to .env and adjust values for your environment.
+###############################################################################
+
+############################
+# Quick-start defaults
+############################
+# Public default model profile (mid-tier, broadly compatible):
+# - Stable local alias consumed by the app
+# - Underlying Ollama source model pulled/used by profile tooling
+LLM_MODEL_NAME=ephemeral-default
+OLLAMA_MODEL_SOURCE=qwen3:8b
+
+# Public default context window for app-side token budgeting.
+LLM_CONTEXT_TOKENS=32768
+
+# Keep Ollama local-only by disabling cloud features (privacy-aligned default).
+OLLAMA_NO_CLOUD=1
+
+############################
+# Required only when changing from bundled defaults
+############################
+# Keep Compose service-name defaults for container-to-container networking unless
+# intentionally integrating external services.
+LLM_BASE_URL=http://ollama:11434/v1
+TIKA_URL=http://tika-server:9998
+
+############################
+# Common user settings
+############################
+APP_DISPLAY_NAME=EphemerAI
+APP_SUBTITLE=Privacy-first document chat
+APP_WELCOME_SUBTITLE=Upload files and chat locally with your documents.
+APP_LOGO_PATH=static/logo.svg
+APP_EXPORT_TITLE=EphemerAI Conversation Export
+SYSTEM_PROMPT_PATH=system_prompt_template.md
+MAX_UPLOAD_MB=50
+DEFAULT_UPLOAD_PROMPT=Summarize the key points from the uploaded document.
+EPHEMERAL_TIMEZONE=
+APP_BIND_ADDRESS=0.0.0.0
+APP_PORT=8501
+
+############################
+# Model/profile settings
+############################
 LLM_OUTPUT_RESERVE_TOKENS=32768
 LLM_REQUEST_TIMEOUT_S=1800
 LLM_MAX_RETRIES=0
+LLM_TEMPERATURE=0.7
+LLM_TOP_P=0.8
+LLM_PRESENCE_PENALTY=1.5
+LLM_REASONING_EFFORT=none
+LLM_THINKING_EFFORT=
+LLM_SHOW_REASONING=false
+LLM_MAX_TOKENS=
+LLM_SUPPORTS_VISION=
+IMG_TOKEN_COST_DEFAULT=1024
+ENABLE_TOKEN_BUDGETING=true
+
+# Ollama runtime tunables
+OLLAMA_NUM_CTX=32768
+OLLAMA_NUM_PREDICT=-1
+OLLAMA_TEMPERATURE=0.7
+OLLAMA_TOP_P=0.8
+OLLAMA_TOP_K=40
+OLLAMA_MIN_P=0.0
+OLLAMA_REPEAT_PENALTY=1.1
+OLLAMA_KV_CACHE_TYPE=f16
+
+############################
+# Advanced/power-user settings
+############################
+OLLAMA_ORIGINS=
+OLLAMA_MAX_QUEUE=16
+OLLAMA_MAX_LOADED_MODELS=1
+OLLAMA_NUM_PARALLEL=1
+OLLAMA_KEEP_ALIVE=-1
+OLLAMA_FLASH_ATTENTION=1
+OLLAMA_FORCE_CUBLAS_LT=1
+TIKA_TIMEOUT_S=120
+TIKA_JAVA_TOOL_OPTIONS=-Xmx2g -Xms512m
+
+############################
+# Optional shared Ollama API exposure
+############################
+# Used by docker-compose.api.yml when intentionally exposing raw Ollama locally.
+OLLAMA_API_BIND=127.0.0.1
+
+############################
+# Debug / troubleshooting
+############################
+EPHEMERAL_DEBUG=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,15 +33,15 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
       - OLLAMA_HOST=0.0.0.0:11434
       - OLLAMA_ORIGINS=${OLLAMA_ORIGINS:-}
-      - OLLAMA_NO_CLOUD=1
-      - OLLAMA_MAX_LOADED_MODELS=1
-      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_NO_CLOUD=${OLLAMA_NO_CLOUD:-1}
+      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-1}
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-1}
       - OLLAMA_MAX_QUEUE=${OLLAMA_MAX_QUEUE:-16}
       # Helpful CUDA GEMM path for supported GPU workloads.
-      - OLLAMA_FORCE_CUBLAS_LT=1
-      - OLLAMA_KEEP_ALIVE=-1
-      - OLLAMA_FLASH_ATTENTION=1
-      - OLLAMA_KV_CACHE_TYPE=q8_0          # Q8 KV cache precision (KV memory only, not model-weight quantization); requires FLASH_ATTENTION=1 above.
+      - OLLAMA_FORCE_CUBLAS_LT=${OLLAMA_FORCE_CUBLAS_LT:-1}
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:--1}
+      - OLLAMA_FLASH_ATTENTION=${OLLAMA_FLASH_ATTENTION:-1}
+      - OLLAMA_KV_CACHE_TYPE=${OLLAMA_KV_CACHE_TYPE:-f16}   # Conservative public default for broad compatibility; high-VRAM profiles can set q8_0.
 
     # Intentionally internal-only on llm-net for privacy; temporarily switch to
     # ports: ["11434:11434"] for local host debugging with curl if needed.
@@ -70,7 +70,7 @@ services:
     restart: unless-stopped
     networks: [llm-net]
     environment:
-      - JAVA_TOOL_OPTIONS=-Xmx2g -Xms512m
+      - JAVA_TOOL_OPTIONS=${TIKA_JAVA_TOOL_OPTIONS:--Xmx2g -Xms512m}
     # Intentionally internal-only on llm-net for privacy; temporarily switch to
     # ports: ["9998:9998"] for local host debugging with curl if needed.
     expose: ["9998"]
@@ -92,27 +92,40 @@ services:
     restart: unless-stopped
     networks: [llm-net]
 
-    ports: ["0.0.0.0:8501:8501"]
+    ports: ["${APP_BIND_ADDRESS:-0.0.0.0}:${APP_PORT:-8501}:8501"]
 
     environment:
-      - LLM_BASE_URL=http://ollama:11434/v1
-      - LLM_MODEL_NAME=ephemeral-default   # Default alias for Qwen3.6-35B-A3B in this stack.
-      - LLM_CONTEXT_TOKENS=262144          # App-side budgeting hint for document/context packing.
-      # Actual Ollama context window is set by PARAMETER num_ctx in the ephemeral-default Modelfile.
+      - APP_DISPLAY_NAME=${APP_DISPLAY_NAME:-EphemerAI}
+      - APP_SUBTITLE=${APP_SUBTITLE:-Privacy-first document chat}
+      - APP_WELCOME_SUBTITLE=${APP_WELCOME_SUBTITLE:-Upload files and chat locally with your documents.}
+      - APP_LOGO_PATH=${APP_LOGO_PATH:-static/logo.svg}
+      - APP_EXPORT_TITLE=${APP_EXPORT_TITLE:-EphemerAI Conversation Export}
+      - SYSTEM_PROMPT_PATH=${SYSTEM_PROMPT_PATH:-system_prompt_template.md}
+      - DEFAULT_UPLOAD_PROMPT=${DEFAULT_UPLOAD_PROMPT:-Summarize the key points from the uploaded document.}
+      - MAX_UPLOAD_MB=${MAX_UPLOAD_MB:-50}
+      - EPHEMERAL_DEBUG=${EPHEMERAL_DEBUG:-false}
+      - EPHEMERAL_TIMEZONE=${EPHEMERAL_TIMEZONE:-}
+      - LLM_BASE_URL=${LLM_BASE_URL:-http://ollama:11434/v1}
+      - LLM_MODEL_NAME=${LLM_MODEL_NAME:-ephemeral-default}
+      - LLM_CONTEXT_TOKENS=${LLM_CONTEXT_TOKENS:-32768}
       - LLM_OUTPUT_RESERVE_TOKENS=${LLM_OUTPUT_RESERVE_TOKENS:-32768}
       - LLM_REQUEST_TIMEOUT_S=${LLM_REQUEST_TIMEOUT_S:-1800}
       - LLM_MAX_RETRIES=${LLM_MAX_RETRIES:-0}
-      - LLM_REASONING_EFFORT=none
-      - LLM_SHOW_REASONING=false
-      - LLM_TEMPERATURE=0.7
-      - LLM_TOP_P=0.8
-      - LLM_PRESENCE_PENALTY=1.5
-      - LLM_MAX_TOKENS=                    # Blank means EphemerAl does not impose an output cap.
-      - TIKA_URL=http://tika-server:9998
+      - LLM_TEMPERATURE=${LLM_TEMPERATURE:-0.7}
+      - LLM_TOP_P=${LLM_TOP_P:-0.8}
+      - LLM_PRESENCE_PENALTY=${LLM_PRESENCE_PENALTY:-1.5}
+      - LLM_REASONING_EFFORT=${LLM_REASONING_EFFORT:-none}
+      - LLM_THINKING_EFFORT=${LLM_THINKING_EFFORT:-}
+      - LLM_SHOW_REASONING=${LLM_SHOW_REASONING:-false}
+      - LLM_MAX_TOKENS=${LLM_MAX_TOKENS:-}
+      - LLM_SUPPORTS_VISION=${LLM_SUPPORTS_VISION:-}
+      - IMG_TOKEN_COST_DEFAULT=${IMG_TOKEN_COST_DEFAULT:-1024}
+      - ENABLE_TOKEN_BUDGETING=${ENABLE_TOKEN_BUDGETING:-true}
+      - TIKA_URL=${TIKA_URL:-http://tika-server:9998}
+      - TIKA_TIMEOUT_S=${TIKA_TIMEOUT_S:-120}
       - TIKA_CLIENT_ONLY=true
       - STREAMLIT_SERVER_HEADLESS=true
       - STREAMLIT_SERVER_ADDRESS=0.0.0.0
-      # - EPHEMERAL_TIMEZONE=America/New_York   # CUSTOMIZE: Override system timezone (optional)
 
     depends_on: [ollama, tika-server]
 


### PR DESCRIPTION
### Motivation
- Make `.env.example` the primary public deployment surface so operators can tune the app and Ollama without source edits. 
- Move public quick-start defaults to a mid-tier model profile and conservative resource defaults to reduce surprise for new users. 
- Surface Ollama/Tika/Streamlit tunables via Compose interpolation so high‑VRAM profiles can be layered later without changing core files.

### Description
- Expanded `.env.example` into labeled sections (Quick-start, Required, Common, Model/profile, Advanced, Optional API exposure, Debug) and added the full app/operator env var surface requested (branding, prompts, model and Ollama runtime knobs, Tika, debug flags, etc.).
- Switched public quick-start defaults to `LLM_MODEL_NAME=ephemeral-default`, `OLLAMA_MODEL_SOURCE=qwen3:8b`, and `LLM_CONTEXT_TOKENS=32768`, and added `OLLAMA_NO_CLOUD=1` with a privacy note.
- Updated `docker-compose.yml` to use `${VAR:-default}` interpolation for key tunables (app bind/port, `LLM_MODEL_NAME`, `LLM_CONTEXT_TOKENS`, Ollama runtime flags, `OLLAMA_KV_CACHE_TYPE` now defaults to `f16`, and Tika JVM options via `TIKA_JAVA_TOOL_OPTIONS`) and passed branding/prompt/upload envs into `ephemeral-app`.
- Intentionally left a small set of operational invariants hardcoded for predictable in-container behavior: `OLLAMA_HOST=0.0.0.0:11434`, `TIKA_CLIENT_ONLY=true`, `STREAMLIT_SERVER_HEADLESS=true`, `STREAMLIT_SERVER_ADDRESS=0.0.0.0`, and `NVIDIA_VISIBLE_DEVICES=all`; these are documented and kept to preserve expected Compose behavior and privacy/operational invariants.

### Testing
- Ran `python -m pytest -q` and all tests passed (`56 passed`).
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py` and compilation succeeded.
- Searched `docker-compose.yml` for hardcoded forms with `rg` and confirmed there are no remaining hardcoded matches for the checked patterns (no occurrences of `LLM_MODEL_NAME=ephemeral-default`, `LLM_CONTEXT_TOKENS=262144`, `OLLAMA_KV_CACHE_TYPE=q8_0`, `OLLAMA_NO_CLOUD=1`, or `JAVA_TOOL_OPTIONS=-Xmx2g`).
- `docker compose config` could not be run in this environment (`docker: command not found`), so Compose-level validation should be run by maintainers or CI that has Docker available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f299130fe88328a7ae997d88364820)