### PR TITLE
Add interactive setup wizard with profile-driven .env onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ To run this interface effectively, the following specifications are recommended.
 
 ## Configuration
 
-Deployment configuration is documented in [`docs/configuration.md`](docs/configuration.md). Use `.env` (copied from `.env.example`) as the primary configuration surface for branding, model, networking, and runtime settings.
+Deployment configuration is documented in [`docs/configuration.md`](docs/configuration.md).
+
+For a guided first-time setup flow, see [`docs/setup-wizard.md`](docs/setup-wizard.md) and run `python scripts/setup_wizard.py`. Use `.env` (copied from `.env.example`) as the primary configuration surface for branding, model, networking, and runtime settings.
 
 Temporary docs link (to be reorganized later): [`docs/doctor.md`](docs/doctor.md) for the `python scripts/doctor.py` health-check command.
 

--- a/docs/setup-wizard.md
+++ b/docs/setup-wizard.md
@@ -1,0 +1,47 @@
+# Setup Wizard (`scripts/setup_wizard.py`)
+
+The setup wizard provides a lightweight, line-oriented terminal flow for first-time setup.
+It is intended for users who can run commands but do not want to edit YAML or Modelfiles.
+
+## What it does
+
+- Detects platform context (Linux/macOS/Windows/WSL/PowerShell where detectable).
+- Checks Docker and Docker Compose availability.
+- Attempts safe NVIDIA detection (`nvidia-smi`, then Docker runtime probe) with graceful fallback.
+- Lets you choose a profile template from `examples/profiles/*.env`:
+  - low-end-laptop
+  - midrange-gpu (default in most cases)
+  - high-vram-workstation
+  - custom/manual
+- Prompts for common settings:
+  - `APP_DISPLAY_NAME`
+  - `APP_PORT`
+  - `LLM_MODEL_NAME`
+  - `OLLAMA_MODEL_SOURCE`
+  - `LLM_CONTEXT_TOKENS` / `OLLAMA_NUM_CTX`
+  - raw Ollama API exposure toggle (default: no)
+  - `OLLAMA_NO_CLOUD` privacy toggle (default: yes / `1`)
+- Validates obvious mistakes (numeric port/context, required model fields).
+- Protects existing `.env` files with overwrite confirmation and timestamped backup.
+- Optionally runs common follow-up commands with explicit per-command confirmation:
+  - `docker compose up -d --build`
+  - `bash scripts/create_ollama_model.sh`
+  - `python scripts/doctor.py`
+
+## Usage
+
+```bash
+python scripts/setup_wizard.py
+```
+
+Help:
+
+```bash
+python scripts/setup_wizard.py --help
+```
+
+## Notes
+
+- The wizard does not make live network calls by itself.
+- Service-start/model-download actions happen only if you approve the optional commands.
+- The midrange profile default uses `qwen3:8b`, which is text-only (not a vision model).

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Interactive setup wizard for generating .env from profile templates."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, Tuple
+
+PROFILE_DIR = Path("examples/profiles")
+PROFILE_MAP = {
+    "low-end-laptop": "low-end-laptop.env",
+    "midrange-gpu": "midrange-gpu.env",
+    "high-vram-workstation": "high-vram-workstation.env",
+}
+
+
+def detect_platform() -> Dict[str, str | bool]:
+    system = platform.system().lower()
+    release = platform.release().lower()
+    shell = os.environ.get("SHELL", "")
+    term_program = os.environ.get("TERM_PROGRAM", "")
+    in_wsl = "microsoft" in release or "wsl" in release or bool(os.environ.get("WSL_DISTRO_NAME"))
+    in_powershell = "pwsh" in os.environ.get("0", "").lower() or "powershell" in shell.lower()
+
+    return {
+        "system": system,
+        "release": release,
+        "in_wsl": in_wsl,
+        "in_powershell": in_powershell,
+        "shell": shell or term_program or "unknown",
+    }
+
+
+def command_exists(command: str) -> bool:
+    return shutil.which(command) is not None
+
+
+def run_probe(command: list[str]) -> Tuple[bool, str]:
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=3, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, str(exc)
+    output = (result.stdout or "") + (result.stderr or "")
+    return result.returncode == 0, output.strip()
+
+
+def detect_nvidia() -> Tuple[bool, str]:
+    if command_exists("nvidia-smi"):
+        ok, output = run_probe(["nvidia-smi", "-L"])
+        if ok and output:
+            return True, "Detected via nvidia-smi"
+        return False, f"nvidia-smi unavailable or failed: {output or 'no output'}"
+
+    ok, output = run_probe(["docker", "info", "--format", "{{json .Runtimes}}"])
+    if ok and "nvidia" in output.lower():
+        return True, "Detected NVIDIA runtime in Docker"
+
+    return False, "No NVIDIA signal detected"
+
+
+def parse_env_template(path: Path) -> Dict[str, str]:
+    data: Dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def choose_default_profile(has_nvidia: bool, platform_info: Dict[str, str | bool]) -> str:
+    if not has_nvidia:
+        return "low-end-laptop"
+    if platform_info.get("in_wsl") and has_nvidia:
+        return "midrange-gpu"
+    return "midrange-gpu"
+
+
+def prompt_text(label: str, default: str, required: bool = False) -> str:
+    while True:
+        value = input(f"{label} [{default}]: ").strip()
+        if not value:
+            value = default
+        if required and not value:
+            print("Value is required.")
+            continue
+        return value
+
+
+def prompt_yes_no(label: str, default: bool) -> bool:
+    suffix = "Y/n" if default else "y/N"
+    value = input(f"{label} ({suffix}): ").strip().lower()
+    if not value:
+        return default
+    return value in {"y", "yes"}
+
+
+def validate_positive_int(value: str, field: str) -> str:
+    if not value.isdigit():
+        raise ValueError(f"{field} must be numeric.")
+    return value
+
+
+def backup_existing_env(env_path: Path) -> Path:
+    stamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    backup_path = env_path.with_suffix(env_path.suffix + f".{stamp}.bak")
+    shutil.copy2(env_path, backup_path)
+    return backup_path
+
+
+def write_env_file(path: Path, env_map: Dict[str, str]) -> None:
+    lines = [f"{key}={value}" for key, value in sorted(env_map.items())]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="EphemerAl setup wizard")
+    parser.add_argument("--non-interactive", action="store_true", help="Reserved for future automation")
+    return parser
+
+
+def main() -> int:
+    build_parser().parse_args()
+    print("== EphemerAl Setup Wizard ==")
+
+    pinfo = detect_platform()
+    docker_ok = command_exists("docker")
+    compose_ok = docker_ok and (run_probe(["docker", "compose", "version"])[0] or command_exists("docker-compose"))
+    nvidia_ok, nvidia_msg = detect_nvidia()
+
+    print(f"Platform: {pinfo['system']} ({pinfo['release']})")
+    print(f"WSL detected: {pinfo['in_wsl']}")
+    print(f"PowerShell detected: {pinfo['in_powershell']}")
+    print(f"Docker available: {docker_ok}")
+    print(f"Docker Compose available: {compose_ok}")
+    print(f"NVIDIA GPU signal: {nvidia_ok} ({nvidia_msg})")
+
+    default_profile = choose_default_profile(nvidia_ok, pinfo)
+    choices = ["low-end-laptop", "midrange-gpu", "high-vram-workstation", "custom/manual"]
+    print("\nProfiles:")
+    for index, name in enumerate(choices, start=1):
+        marker = " (default)" if name == default_profile else ""
+        print(f"  {index}. {name}{marker}")
+
+    selected = input(f"Select profile [default {default_profile}]: ").strip()
+    selected_profile = default_profile
+    if selected:
+        if selected.isdigit() and 1 <= int(selected) <= len(choices):
+            selected_profile = choices[int(selected) - 1]
+        elif selected in choices:
+            selected_profile = selected
+
+    env_values: Dict[str, str] = {}
+    if selected_profile != "custom/manual":
+        template_path = PROFILE_DIR / PROFILE_MAP[selected_profile]
+        env_values = parse_env_template(template_path)
+        print(f"Loaded profile template: {template_path}")
+    else:
+        print("Starting from empty values for custom/manual profile.")
+
+    env_values["APP_DISPLAY_NAME"] = prompt_text("App display name", env_values.get("APP_DISPLAY_NAME", "EphemerAI"), required=True)
+    env_values["APP_PORT"] = validate_positive_int(prompt_text("App port", env_values.get("APP_PORT", "8501"), required=True), "App port")
+    env_values["LLM_MODEL_NAME"] = prompt_text("Model alias name", env_values.get("LLM_MODEL_NAME", "ephemeral-default"), required=True)
+    env_values["OLLAMA_MODEL_SOURCE"] = prompt_text("Model source tag", env_values.get("OLLAMA_MODEL_SOURCE", "qwen3:8b"), required=True)
+    env_values["LLM_CONTEXT_TOKENS"] = validate_positive_int(prompt_text("Context size", env_values.get("LLM_CONTEXT_TOKENS", "32768"), required=True), "Context size")
+    env_values["OLLAMA_NUM_CTX"] = env_values["LLM_CONTEXT_TOKENS"]
+
+    expose_raw = prompt_yes_no("Expose raw Ollama API externally?", default=False)
+    if expose_raw:
+        print("WARNING: Exposing raw Ollama API can allow unauthenticated access if network controls are weak.")
+    env_values["EXPOSE_RAW_OLLAMA_API"] = "1" if expose_raw else "0"
+
+    no_cloud = prompt_yes_no("Keep Ollama cloud features disabled (OLLAMA_NO_CLOUD=1)?", default=True)
+    if not no_cloud:
+        print("PRIVACY WARNING: Disabling OLLAMA_NO_CLOUD may allow cloud-connected behavior.")
+    env_values["OLLAMA_NO_CLOUD"] = "1" if no_cloud else "0"
+
+    env_path = Path(".env")
+    if env_path.exists():
+        if not prompt_yes_no(".env already exists. Overwrite?", default=False):
+            print("Aborted. Existing .env kept unchanged.")
+            return 0
+        backup = backup_existing_env(env_path)
+        print(f"Backed up existing .env to: {backup}")
+
+    write_env_file(env_path, env_values)
+    print("Wrote .env successfully.")
+    print("Note: default midrange profile uses qwen3:8b (text-only, not a vision model).")
+
+    if prompt_yes_no("Run 'docker compose up -d --build'?", default=False):
+        print("About to run: docker compose up -d --build")
+        subprocess.run(["docker", "compose", "up", "-d", "--build"], check=False)
+    if prompt_yes_no("Run 'bash scripts/create_ollama_model.sh'? (may download models)", default=False):
+        print("About to run: bash scripts/create_ollama_model.sh")
+        subprocess.run(["bash", "scripts/create_ollama_model.sh"], check=False)
+    if prompt_yes_no("Run 'python scripts/doctor.py'?", default=True):
+        print("About to run: python scripts/doctor.py")
+        subprocess.run(["python", "scripts/doctor.py"], check=False)
+
+    print("Setup complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.setup_wizard import (
+    choose_default_profile,
+    parse_env_template,
+    validate_positive_int,
+)
+
+
+def test_parse_env_template_reads_key_values(tmp_path: Path) -> None:
+    env_file = tmp_path / "sample.env"
+    env_file.write_text("# comment\nA=1\nB = two\n\n", encoding="utf-8")
+
+    parsed = parse_env_template(env_file)
+
+    assert parsed == {"A": "1", "B": "two"}
+
+
+def test_choose_default_profile_midrange_when_nvidia() -> None:
+    assert choose_default_profile(True, {"in_wsl": False}) == "midrange-gpu"
+
+
+def test_choose_default_profile_low_end_when_no_nvidia() -> None:
+    assert choose_default_profile(False, {"in_wsl": False}) == "low-end-laptop"
+
+
+def test_validate_positive_int_accepts_digits() -> None:
+    assert validate_positive_int("8501", "App port") == "8501"
+
+
+@pytest.mark.parametrize("value", ["", "abc", "85a"])
+def test_validate_positive_int_rejects_non_numeric(value: str) -> None:
+    with pytest.raises(ValueError):
+        validate_positive_int(value, "Context size")


### PR DESCRIPTION
### Motivation
- Provide a simple, line-oriented CLI for first-time users to create a working `.env` without editing YAML or Modelfiles. 
- Make profile selection and common settings safe and discoverable by detecting platform, Docker/Compose, and NVIDIA signals before suggesting defaults. 
- Preserve privacy and avoid surprising network activity by defaulting to local-only settings and asking before any service start or model download commands.

### Description
- Add `scripts/setup_wizard.py`, a standard-library-only interactive wizard that detects OS/WSL/PowerShell, checks `docker`/Compose, probes for NVIDIA via `nvidia-smi` and Docker runtime, loads templates from `examples/profiles/*.env`, prompts for common settings, validates inputs, warns on risky choices, and writes `.env` with overwrite confirmation and a timestamped backup. 
- Default profile selection favors `midrange-gpu` unless detection indicates no NVIDIA device, and the wizard explicitly defaults to not exposing raw Ollama (`EXPOSE_RAW_OLLAMA_API=0`) and to keep cloud features disabled (`OLLAMA_NO_CLOUD=1`). 
- Offer optional, per-command confirmation for follow-ups and print the exact commands before running: `docker compose up -d --build`, `bash scripts/create_ollama_model.sh`, and `python scripts/doctor.py`. 
- Add unit tests for pure helpers in `tests/test_setup_wizard.py`, add user-facing docs at `docs/setup-wizard.md`, and link the docs from `README.md`.

### Testing
- Ran `python scripts/setup_wizard.py --help` and the script printed the help usage successfully. 
- Ran `pytest -q tests/test_setup_wizard.py` which passed and then `python -m pytest -q` which completed with all tests passing. 
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/setup_wizard.py scripts/doctor.py` with no syntax errors, and `ruff check .` which reported all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ad7033908328a8228eeae3414090)