### PR TITLE
Add cross-platform bootstrap scripts and onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ For a guided first-time setup flow, see [`docs/setup-wizard.md`](docs/setup-wiza
 
 Temporary docs link (to be reorganized later): [`docs/doctor.md`](docs/doctor.md) for the `python scripts/doctor.py` health-check command.
 
+For one-command first-time setup, use the bootstrap scripts: [`docs/bootstrap.md`](docs/bootstrap.md).
+
 ## Deployment
 
 Use the step-by-step guide:

--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -196,6 +196,17 @@ docker run --rm --gpus all nvidia/cuda:12.6.3-base-ubuntu24.04 nvidia-smi
 You should see a table showing your GPU name, driver version, and VRAM. If this fails, your NVIDIA driver may need updating, or the toolkit install did not complete. Go back to Step 2c and confirm each command ran without errors.
 
 
+## Quick Start (Recommended)
+
+Before following the full manual workflow below, try the one-command bootstrap first:
+
+```bash
+cd ~/ephemeral-llm
+bash scripts/bootstrap.sh
+```
+
+If bootstrap cannot complete in your environment, continue with the manual steps in this guide.
+
 ## Step 3: Deploy EphemerAl and Create the Qwen Alias
 
 This step starts the stack, pulls the Qwen model, and creates the local alias EphemerAl expects.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,0 +1,70 @@
+# Bootstrap Scripts
+
+Use these scripts for a safe, one-command first run. They validate prerequisites, create `.env` when missing, start the stack, create the model alias, and run the doctor checks.
+
+## What bootstrap does
+
+1. Checks Docker + Docker Compose.
+2. Checks Git and Python availability.
+3. Optionally runs `scripts/setup_wizard.py` when `.env` is missing.
+4. Otherwise copies `.env.example` to `.env` and prompts you to review values.
+5. Runs `docker compose up -d --build`.
+6. Runs `scripts/create_ollama_model.sh`.
+7. Runs `python scripts/doctor.py`.
+
+Notes:
+- The scripts do **not** install Docker, GPU drivers, NVIDIA toolkit, or OS packages.
+- Raw Ollama API remains internal by default.
+- `OLLAMA_NO_CLOUD=1` remains the default privacy setting.
+
+## Linux / macOS / WSL
+
+From repository root:
+
+```bash
+bash scripts/bootstrap.sh
+```
+
+Preview actions without changing anything:
+
+```bash
+bash scripts/bootstrap.sh --dry-run
+```
+
+Show options:
+
+```bash
+bash scripts/bootstrap.sh --help
+```
+
+Non-interactive mode:
+
+```bash
+bash scripts/bootstrap.sh --yes
+```
+
+## Windows / PowerShell
+
+From repository root in PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1
+```
+
+Preview actions without changing anything:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1 -DryRun
+```
+
+Show options:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1 -Help
+```
+
+Non-interactive mode:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1 -Yes
+```

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,0 +1,98 @@
+[CmdletBinding()]
+param(
+  [switch]$DryRun,
+  [switch]$Yes,
+  [switch]$Help
+)
+
+if ($Help) {
+  @"
+Usage: powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1 [-DryRun] [-Yes] [-Help]
+
+Bootstraps EphemerAl for Windows/PowerShell:
+- checks prerequisites (Docker, Docker Compose, Python, Git)
+- optionally runs setup wizard or creates .env from .env.example
+- starts containers via docker compose
+- creates/updates Ollama model alias
+- runs doctor checks
+"@ | Write-Host
+  exit 0
+}
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+function Say([string]$Msg) { Write-Host $Msg }
+function Warn([string]$Msg) { Write-Warning $Msg }
+function Fail([string]$Msg) { throw $Msg }
+function Run-Step([string]$Cmd, [string[]]$Args) {
+  if ($DryRun) {
+    Write-Host "[dry-run] $Cmd $($Args -join ' ')"
+    return
+  }
+  & $Cmd @Args
+}
+function Confirm-Step([string]$Prompt) {
+  if ($Yes) { return $true }
+  $answer = Read-Host "$Prompt [y/N]"
+  return $answer -match '^[Yy]$'
+}
+
+Say "EphemerAl bootstrap will do the following:"
+Say "  1) Validate local prerequisites"
+Say "  2) Prepare .env if missing"
+Say "  3) Run docker compose up -d --build"
+Say "  4) Run scripts/create_ollama_model.sh"
+Say "  5) Run python scripts/doctor.py"
+
+$dockerCmd = Get-Command docker -ErrorAction SilentlyContinue
+if (-not $dockerCmd) { Fail 'Docker is not installed or not on PATH.' }
+try { & docker info *> $null } catch { Fail 'Docker is installed but not running. Start Docker Desktop and retry.' }
+try { & docker compose version *> $null } catch { Fail 'Docker Compose (docker compose) is unavailable.' }
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) { Fail 'Git is not installed or not on PATH.' }
+
+$pythonCmd = $null
+if (Get-Command python -ErrorAction SilentlyContinue) { $pythonCmd = 'python' }
+elseif (Get-Command py -ErrorAction SilentlyContinue) { $pythonCmd = 'py'; }
+else { Warn 'Python was not found. setup_wizard.py and doctor.py cannot run.' }
+
+if (-not (Test-Path '.env')) {
+  if ($pythonCmd -and (Confirm-Step '.env is missing. Run guided setup wizard now?')) {
+    if ($pythonCmd -eq 'py') { Run-Step 'py' @('-3','scripts/setup_wizard.py') }
+    else { Run-Step $pythonCmd @('scripts/setup_wizard.py') }
+  } else {
+    if (-not (Test-Path '.env.example')) { Fail '.env.example was not found, cannot create .env.' }
+    if ($DryRun) { Say '[dry-run] Copy-Item .env.example .env' }
+    else { Copy-Item '.env.example' '.env' }
+    Say 'Created .env from .env.example. Please review and adjust .env for your environment.'
+  }
+}
+
+if ((Test-Path '.env') -and ((Get-Content '.env' | Select-String -Pattern '^\s*OLLAMA_KV_CACHE_TYPE\s*=\s*q8').Count -gt 0)) {
+  $nvidiaSmi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+  $nvidiaCtk = Get-Command nvidia-ctk -ErrorAction SilentlyContinue
+  if (-not $nvidiaSmi -and -not $nvidiaCtk) {
+    Warn 'High-VRAM GPU profile detected (OLLAMA_KV_CACHE_TYPE=q8), but NVIDIA tooling was not found. GPU acceleration may fail.'
+  }
+}
+
+Run-Step 'docker' @('compose','up','-d','--build')
+
+if (Get-Command bash -ErrorAction SilentlyContinue) {
+  Run-Step 'bash' @('scripts/create_ollama_model.sh')
+} elseif (Get-Command wsl -ErrorAction SilentlyContinue) {
+  Run-Step 'wsl' @('bash','-lc','cd "' + $repoRoot + '" && bash scripts/create_ollama_model.sh')
+} else {
+  Fail 'Could not run scripts/create_ollama_model.sh. Install Git Bash or enable WSL.'
+}
+
+if (-not $pythonCmd) {
+  Warn 'Skipping doctor check because Python is unavailable.'
+} elseif ($pythonCmd -eq 'py') {
+  Run-Step 'py' @('-3','scripts/doctor.py')
+} else {
+  Run-Step $pythonCmd @('scripts/doctor.py')
+}
+
+Say ('Bootstrap completed' + ($(if ($DryRun) { ' (dry run).' } else { '.' })))

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/bootstrap.sh [--dry-run] [--yes] [--help]
+
+Bootstraps EphemerAl for Linux/macOS/WSL:
+- checks prerequisites (Docker, Docker Compose, Python, Git)
+- optionally runs setup wizard or creates .env from .env.example
+- starts containers via docker compose
+- creates/updates Ollama model alias
+- runs doctor checks
+
+Options:
+  --dry-run   Show planned steps without changing anything.
+  --yes       Non-interactive mode; auto-accept safe defaults.
+  --help      Show this help.
+USAGE
+}
+
+DRY_RUN=false
+ASSUME_YES=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true ;;
+    --yes) ASSUME_YES=true ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "Error: Unknown argument '$1'. Use --help." >&2; exit 1 ;;
+  esac
+  shift
+done
+
+say() { printf '%s\n' "$*"; }
+warn() { printf 'Warning: %s\n' "$*" >&2; }
+fail() { printf 'Error: %s\n' "$*" >&2; exit 1; }
+run_cmd() {
+  if [[ "$DRY_RUN" == true ]]; then
+    say "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  if [[ "$ASSUME_YES" == true ]]; then
+    return 0
+  fi
+  read -r -p "$prompt [y/N]: " ans
+  [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+check_cmd() {
+  local bin="$1" label="$2"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    fail "$label is not installed or not on PATH."
+  fi
+}
+
+say "EphemerAl bootstrap will do the following:"
+say "  1) Validate local prerequisites"
+say "  2) Prepare .env if missing"
+say "  3) Run docker compose up -d --build"
+say "  4) Run scripts/create_ollama_model.sh"
+say "  5) Run python scripts/doctor.py"
+
+check_cmd docker "Docker"
+if ! docker info >/dev/null 2>&1; then
+  fail "Docker is installed but not running. Start Docker and try again."
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  fail "Docker Compose (docker compose) is unavailable. Install/enable Compose v2."
+fi
+check_cmd git "Git"
+
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  warn "Python was not found. setup_wizard.py and doctor.py cannot run."
+fi
+
+if [[ "${OSTYPE:-}" == linux* ]] || grep -qi microsoft /proc/version 2>/dev/null; then
+  if [[ -f .env ]] && grep -Eq '^\s*OLLAMA_KV_CACHE_TYPE\s*=\s*q8' .env; then
+    if ! command -v nvidia-smi >/dev/null 2>&1 && ! command -v nvidia-ctk >/dev/null 2>&1; then
+      warn "High-VRAM GPU profile detected (OLLAMA_KV_CACHE_TYPE=q8), but NVIDIA tooling was not found. GPU acceleration may fail."
+    fi
+  fi
+fi
+
+if [[ ! -f .env ]]; then
+  if [[ -n "$PYTHON_BIN" ]] && confirm ".env is missing. Run guided setup wizard now?"; then
+    run_cmd "$PYTHON_BIN" scripts/setup_wizard.py
+  else
+    [[ -f .env.example ]] || fail ".env.example was not found, cannot create .env."
+    run_cmd cp .env.example .env
+    say "Created .env from .env.example. Please review and adjust .env for your environment."
+  fi
+fi
+
+run_cmd docker compose up -d --build
+run_cmd bash scripts/create_ollama_model.sh
+
+if [[ -z "$PYTHON_BIN" ]]; then
+  warn "Skipping doctor check because Python is unavailable."
+else
+  run_cmd "$PYTHON_BIN" scripts/doctor.py
+fi
+
+say "Bootstrap completed${DRY_RUN:+ (dry run)}."


### PR DESCRIPTION
### Motivation
- Provide a safe, one-command bootstrap flow to validate prerequisites, create or guide creation of `.env`, start the Compose stack, create the local Ollama model alias, and run runtime health checks.
- Make first-time onboarding consistent across Linux/macOS/WSL and Windows while preserving privacy defaults such as `OLLAMA_NO_CLOUD=1` and avoiding automatic system/package installation.
- Reduce manual, error-prone steps in the deployment guide by giving users a tested fast path and linking it from primary docs.

### Description
- Add `scripts/bootstrap.sh` (Linux/macOS/WSL) implementing `--help`, `--dry-run`, and `--yes`, with plain-language preflight checks for Docker, Docker Compose, Git, and Python, an optional interactive `scripts/setup_wizard.py` run or `.env` fallback copy, `docker compose up -d --build`, invocation of `scripts/create_ollama_model.sh`, and running `python scripts/doctor.py`, plus a warning when high-VRAM `q8` profiles are used but NVIDIA tooling is missing.
- Add `scripts/bootstrap.ps1` (PowerShell) with equivalent checks/options and a safe fallback to run the model-creation script via `bash` or `wsl` when appropriate on Windows.
- Add `docs/bootstrap.md` with platform-specific usage examples and dry-run/help usage, update `README.md` to link the bootstrap docs, and update `System Deployment Guide.md` to recommend running the bootstrap first with manual setup as a fallback.
- Preserve privacy and safety invariants by not installing system packages or drivers, keeping raw Ollama API internal by default, and retaining `OLLAMA_NO_CLOUD=1` behavior.

### Testing
- Ran `bash scripts/bootstrap.sh --help`, which printed the usage/help successfully (PASS).
- Ran `bash scripts/bootstrap.sh --dry-run`, which exited early with a plain-language failure because Docker is not available in this validation environment (expected validation behavior / expected failure for this environment).
- Attempted PowerShell parse/validation but `pwsh` is not available in this environment, so PowerShell script requires validation on Windows (SKIPPED here).
- Ran `python -m pytest -q` (result: `69 passed`), `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` (succeeded), and `ruff check .` (All checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b93a96108328a1173274fa231e1b)