### PR TITLE
Add public release audit script and finalize public-release cleanup

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-**Copyright (c) 2025 Ethan Owens (eowensai)**
+**Copyright (c) 2025 Ethan Owens**
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -128,7 +128,7 @@ http://localhost:8501
 Use this only if the helper script cannot satisfy your custom runtime needs.
 
 - Enter Ollama container.
-- Create/edit a Modelfile.
+- Create a deployment profile file (for example under `examples/profiles/`) and keep model settings there rather than direct source edits.
 - Run `ollama create <alias> -f <modelfile>`.
 - Keep `LLM_MODEL_NAME` aligned with your alias in `.env`.
 

--- a/docs/setup-wizard.md
+++ b/docs/setup-wizard.md
@@ -1,7 +1,7 @@
 # Setup Wizard (`scripts/setup_wizard.py`)
 
 The setup wizard provides a lightweight, line-oriented terminal flow for first-time setup.
-It is intended for users who can run commands but do not want to edit YAML or Modelfiles.
+It is intended for users who can run commands and prefer profile-driven configuration rather than direct source changes.
 
 ## What it does
 

--- a/scripts/audit_public_release.py
+++ b/scripts/audit_public_release.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Public release audit for repository hygiene.
+
+Uses only Python standard library.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXCLUDED_DIRS = {
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".venv",
+    "venv",
+    "env",
+    "node_modules",
+    "artifacts",
+    "dist",
+    "build",
+}
+
+BINARY_EXTENSIONS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".ico", ".pdf", ".zip", ".gz", ".tar", ".mp4", ".mp3", ".woff", ".woff2",
+}
+
+ALLOWLIST_TERMS = {
+    "EphemerAl",
+    "EphemerAI",
+    "Ollama",
+    "Apache Tika",
+    "localhost",
+    "example.com",
+    "test@example.com",
+}
+
+ALLOWLIST_FILE_SUBSTRINGS = {
+    "tests/fixtures/",
+    "scripts/audit_public_release.py",
+}
+
+SENTINEL = "# audit-allowlist: contains forbidden-term list for testing"
+
+@dataclass
+class Rule:
+    category: str
+    pattern: re.Pattern[str]
+    high_confidence: bool = False
+
+
+RULES: list[Rule] = [
+    Rule("Organization/person identity terms", re.compile(r"\b(University of Washington|\bUW\b|\bHFS\b|StarRez|Transact|Workday|SharePoint|OneDrive|\bTeams\b|eowensai|day job|our team's sensitive)\b", re.IGNORECASE), high_confidence=True),
+    Rule("Personal URLs/emails", re.compile(r"https?://(?:www\.)?github\.com/(?!ollama(?:/|$))[A-Za-z0-9_.-]+/?|\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b", re.IGNORECASE), high_confidence=True),
+    Rule("Secret-like patterns", re.compile(r"\b(sk-[A-Za-z0-9]{16,}|ghp_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN (?:RSA|OPENSSH|EC|DSA) PRIVATE KEY-----|xox[baprs]-[A-Za-z0-9-]{10,})"), high_confidence=True),
+    Rule("Hardcoded old branding that should now be config-driven", re.compile(r"\bEphemeral Screenshot\.jpg\b|\bEphemeral%20Screenshot\.jpg\b|\bephemeral_logo_old\b", re.IGNORECASE)),
+    Rule("Manual Modelfile/YAML/source-editing instructions in docs", re.compile(r"\b(edit|modify|open)\b.{0,80}\b(Modelfile|docker-compose\.yml|source code|yaml)\b", re.IGNORECASE)),
+    Rule("Orphan/default-brand binary asset references where detectable", re.compile(r"\b(static/)?ephemeral_logo_old\.png\b|\bEphemeral(?:%20| )Screenshot\.jpg\b", re.IGNORECASE)),
+    Rule("Privacy posture drift, such as OLLAMA_NO_CLOUD disabled by default", re.compile(r"OLLAMA_NO_CLOUD\s*(?:=|:)\s*(?:0|false|False)")),
+]
+
+
+def redact_secret(value: str) -> str:
+    if len(value) <= 10:
+        return value
+    return value[:4] + "…" + value[-4:]
+
+
+def is_probably_text(path: Path) -> bool:
+    if path.suffix.lower() in BINARY_EXTENSIONS:
+        return False
+    try:
+        with path.open("rb") as f:
+            chunk = f.read(2048)
+        if b"\x00" in chunk:
+            return False
+    except OSError:
+        return False
+    return True
+
+
+def iter_files(root: Path) -> Iterable[Path]:
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIRS and not d.startswith(".venv")]
+        for name in filenames:
+            path = Path(dirpath) / name
+            rel = path.relative_to(root).as_posix()
+            if any(part in rel for part in ALLOWLIST_FILE_SUBSTRINGS):
+                continue
+            if is_probably_text(path):
+                yield path
+
+
+def allowlisted(path: Path, line: str) -> bool:
+    for term in ALLOWLIST_TERMS:
+        if term in line:
+            return True
+    rel = path.relative_to(ROOT).as_posix()
+    if rel == "tests/test_system_prompt.py":
+        try:
+            first = path.read_text(encoding="utf-8", errors="replace").splitlines()[0]
+        except Exception:
+            return False
+        if first == SENTINEL:
+            return True
+    return False
+
+
+def main() -> int:
+    findings: list[tuple[str, int, str, str, bool]] = []
+    for path in iter_files(ROOT):
+        rel = path.relative_to(ROOT).as_posix()
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for rule in RULES:
+                for match in rule.pattern.finditer(line):
+                    token = match.group(0)
+                    if allowlisted(path, line):
+                        continue
+                    snippet = line.strip()
+                    if rule.category == "Secret-like patterns":
+                        snippet = snippet.replace(token, redact_secret(token))
+                    findings.append((rel, lineno, snippet, rule.category, rule.high_confidence))
+
+    if not findings:
+        print("No findings.")
+        return 0
+
+    findings.sort()
+    grouped: dict[str, list[tuple[str, int, str, bool]]] = {}
+    for rel, lineno, snippet, category, high in findings:
+        grouped.setdefault(category, []).append((rel, lineno, snippet, high))
+
+    high_count = 0
+    for category, items in grouped.items():
+        print(f"\n[{category}] ({len(items)} findings)")
+        for rel, lineno, snippet, high in items:
+            high_count += 1 if high else 0
+            print(f"- {rel}:{lineno}: {snippet}")
+
+    return 2 if high_count else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide an automated, standard-library-only audit to detect organization/personal identifiers, secrets, hardcoded branding, and privacy posture regressions prior to public release.
- Remove remaining personal handles and source-editing guidance that could leak org/user identities or encourage direct source edits instead of profile-driven configuration.

### Description
- Add `scripts/audit_public_release.py`, a Python-3-only script that scans repository text files (with VCS/cache/venv/binary exclusions), groups findings into the requested categories, supports an allowlist, respects the `tests/test_system_prompt.py` sentinel, redacts secret-like values, and exits nonzero on high-confidence findings.
- Tighten the personal-URL rule to avoid flagging the `ollama` organization and add the audit script itself to internal allowlist substrings to avoid self-matches.
- Update `System Deployment Guide.md` to prefer profile-driven model configuration (`examples/profiles/`) instead of instructing users to "create/edit a Modelfile." 
- Update `docs/setup-wizard.md` wording to emphasize profile-driven configuration rather than direct YAML/Modelfile edits.
- Remove the personal handle from the `LICENSE.md` copyright line (keeps `LICENSE.md` intact per constraints).

### Testing
- Ran `python scripts/audit_public_release.py` and the audit reported `No findings.` and exited `0` after the cleanup changes.
- Ran `python -m pytest -q` with `69 passed` (all tests passed).
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` which succeeded without errors.
- Ran `ruff check .` which reported `All checks passed!`.
- Attempted `docker compose config` but the environment lacks Docker (`docker: command not found`).
- Verified targeted `rg` sweep (excluding `tests/test_system_prompt.py` and the audit script) returned zero matches for forbidden terms.

Notes / remaining items requiring human/legal decision:
- `LICENSE.md` still names an individual copyright holder (`Ethan Owens`), which may be acceptable but is a legal/policy decision to change.
- Git history author emails remain in the repository history; changing those requires history rewrite and was intentionally not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cbdbbbc48328ba09be7f82facf77)