### PR TITLE
Harden create_ollama_model dotenv parsing for spaced values

### DIFF
--- a/scripts/create_ollama_model.sh
+++ b/scripts/create_ollama_model.sh
@@ -13,11 +13,61 @@ elif [[ $# -gt 0 ]]; then
   exit 1
 fi
 
+read_dotenv_value() {
+  local raw="$1"
+  local value="${raw#"${raw%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  if [[ "${value}" =~ ^\"(.*)\"$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  if [[ "${value}" =~ ^\'(.*)\'$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  printf '%s' "${value}"
+}
+
+load_selected_dotenv() {
+  local dotenv_path="$1"
+  local -A allowed=(
+    [OLLAMA_CONTAINER]=1
+    [OLLAMA_MODEL_SOURCE]=1
+    [LLM_MODEL_NAME]=1
+    [OLLAMA_NUM_CTX]=1
+    [OLLAMA_NUM_PREDICT]=1
+    [OLLAMA_TEMPERATURE]=1
+    [LLM_TEMPERATURE]=1
+    [OLLAMA_TOP_P]=1
+    [LLM_TOP_P]=1
+    [OLLAMA_TOP_K]=1
+    [OLLAMA_MIN_P]=1
+    [OLLAMA_REPEAT_PENALTY]=1
+    [OLLAMA_KV_CACHE_TYPE]=1
+  )
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    local trimmed="${line#"${line%%[![:space:]]*}"}"
+    if [[ -z "${trimmed}" || "${trimmed:0:1}" == "#" ]]; then
+      continue
+    fi
+    if [[ ! "${trimmed}" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      continue
+    fi
+    local key="${BASH_REMATCH[1]}"
+    local raw_value="${BASH_REMATCH[2]}"
+    if [[ -z "${allowed[${key}]:-}" ]]; then
+      continue
+    fi
+    local parsed
+    parsed="$(read_dotenv_value "${raw_value}")"
+    printf -v "${key}" '%s' "${parsed}"
+    export "${key}"
+  done < "${dotenv_path}"
+}
+
 if [[ -f "${REPO_ROOT}/.env" ]]; then
-    set -a
-  # shellcheck disable=SC1091
-  source "${REPO_ROOT}/.env"
-  set +a
+  load_selected_dotenv "${REPO_ROOT}/.env"
 fi
 
 OLLAMA_CONTAINER="${OLLAMA_CONTAINER:-ollama}"

--- a/tests/test_create_ollama_model_script.py
+++ b/tests/test_create_ollama_model_script.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "create_ollama_model.sh"
+ENV_FILE = ROOT / ".env"
+
+
+def _run_dry_run() -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--dry-run"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_create_ollama_model_dry_run_without_env() -> None:
+    original = ENV_FILE.read_text(encoding="utf-8") if ENV_FILE.exists() else None
+    try:
+        ENV_FILE.unlink(missing_ok=True)
+        result = _run_dry_run()
+        assert result.returncode == 0, result.stderr
+        assert "Dry run enabled. No commands will be executed." in result.stdout
+    finally:
+        if original is None:
+            ENV_FILE.unlink(missing_ok=True)
+        else:
+            ENV_FILE.write_text(original, encoding="utf-8")
+
+
+def test_create_ollama_model_dry_run_accepts_env_example() -> None:
+    original = ENV_FILE.read_text(encoding="utf-8") if ENV_FILE.exists() else None
+    try:
+        shutil.copyfile(ROOT / ".env.example", ENV_FILE)
+        result = _run_dry_run()
+        assert result.returncode == 0, result.stderr
+        assert "Dry run enabled. No commands will be executed." in result.stdout
+    finally:
+        if original is None:
+            ENV_FILE.unlink(missing_ok=True)
+        else:
+            ENV_FILE.write_text(original, encoding="utf-8")
+
+
+def test_create_ollama_model_dry_run_accepts_profile_env() -> None:
+    original = ENV_FILE.read_text(encoding="utf-8") if ENV_FILE.exists() else None
+    try:
+        shutil.copyfile(ROOT / "examples/profiles/midrange-gpu.env", ENV_FILE)
+        result = _run_dry_run()
+        assert result.returncode == 0, result.stderr
+        assert "Dry run enabled. No commands will be executed." in result.stdout
+    finally:
+        if original is None:
+            ENV_FILE.unlink(missing_ok=True)
+        else:
+            ENV_FILE.write_text(original, encoding="utf-8")


### PR DESCRIPTION
### Motivation
- The script previously `source`d `.env`, which treats unquoted spaces as shell tokens and can both break valid dotenv entries and execute arbitrary shell code.
- The goal is to safely import only the variables the model-creation script needs and avoid executing `.env` content as shell commands.

### Description
- Replace unsafe `source` behavior with a safe parser: added `read_dotenv_value` to trim and unquote single/double-quoted values and `load_selected_dotenv` to read `.env` line-by-line while ignoring blanks and comments.
- Only allowlist-import keys required by the model flow (`OLLAMA_CONTAINER`, `OLLAMA_MODEL_SOURCE`, `LLM_MODEL_NAME`, `OLLAMA_NUM_CTX`, `OLLAMA_NUM_PREDICT`, `OLLAMA_TEMPERATURE`, `LLM_TEMPERATURE`, `OLLAMA_TOP_P`, `LLM_TOP_P`, `OLLAMA_TOP_K`, `OLLAMA_MIN_P`, `OLLAMA_REPEAT_PENALTY`, `OLLAMA_KV_CACHE_TYPE`) and `export` them without evaluating shell code.
- Preserve existing defaults, validation (`validate_values`) and the `--dry-run` behavior that prints resolved settings and planned commands without touching Docker or the container.
- Add `tests/test_create_ollama_model_script.py` to exercise `create_ollama_model.sh --dry-run` with no `.env`, with `.env.example`, and with `examples/profiles/midrange-gpu.env`.

### Testing
- Ran `python -m pytest -q`, which completed successfully with `72 passed` including the new `tests/test_create_ollama_model_script.py` tests.
- Ran `bash -n scripts/*.sh` to syntax-check shell scripts and it returned no errors.
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` which succeeded with no compilation errors.
- Ran `python scripts/audit_public_release.py` which reported `No findings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d5b5c3148328805788e92bd53949)