### PR TITLE
Fix LLM_SUPPORTS_VISION blank override handling

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ Exposing raw Ollama on the network is optional and should be deliberate: direct 
 | `LLM_THINKING_EFFORT` | _(empty)_ | No | Provider/model-supported string or empty | Alternate/extra effort hint for models exposing “thinking” controls. | Only when using models that honor this knob. |
 | `LLM_SHOW_REASONING` | `false` | No | `true`/`false` | Controls whether reasoning/thought output is surfaced when available. | Debugging or specialized UX needs. |
 | `LLM_MAX_TOKENS` | _(empty)_ | No | Empty or positive integer | Optional output token cap for model responses. | Enforce bounded response length/cost. |
-| `LLM_SUPPORTS_VISION` | _(empty)_ | No | Empty/auto, or boolean-like override depending on deployment conventions | Optional capability hint for image support. | Force/override detection edge cases. |
+| `LLM_SUPPORTS_VISION` | _(empty)_ | No | Empty/whitespace = auto-detect; truthy: `1,true,yes,y,on`; falsy: `0,false,no,n,off` | Optional capability hint for image support. | Force/override detection edge cases while keeping blank as auto-detect. |
 | `IMG_TOKEN_COST_DEFAULT` | `1024` | No | Positive integer estimated tokens/image | Budgeting estimate per image attachment. | Calibrate budgeting for your model behavior. |
 | `ENABLE_TOKEN_BUDGETING` | `true` | No | `true`/`false` | Enables app-side context budgeting safeguards. | Disable only for controlled experiments. |
 | `TIKA_URL` | `http://tika-server:9998` | Yes (unless app default matches environment) | URL to Apache Tika server | Document parsing backend endpoint. | Point to external Tika or different network path. |

--- a/ephemeral/config.py
+++ b/ephemeral/config.py
@@ -69,10 +69,19 @@ def _bool_env(name: str, default: bool = False) -> bool:
     return default
 
 
+def _optional_env(name: str) -> Optional[str]:
+    """Return stripped env value, or None for unset/blank/whitespace-only."""
+    raw = os.getenv(name)
+    if raw is None:
+        return None
+    value = raw.strip()
+    return value or None
+
+
 LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://ollama:11434/v1")
 LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "ephemeral-default")
 TIKA_URL = os.getenv("TIKA_URL", "http://tika-server:9998")
-LLM_SUPPORTS_VISION = os.getenv("LLM_SUPPORTS_VISION")
+LLM_SUPPORTS_VISION = _optional_env("LLM_SUPPORTS_VISION")
 
 APP_DISPLAY_NAME = os.getenv("APP_DISPLAY_NAME", "EphemerAI")
 APP_SUBTITLE = os.getenv("APP_SUBTITLE", "Private AI Assistant")

--- a/ephemeral/llm_client.py
+++ b/ephemeral/llm_client.py
@@ -86,7 +86,11 @@ def model_supports_images() -> bool:
       3) Ollama model_info heuristics as a fallback.
     """
     if LLM_SUPPORTS_VISION is not None:
-        return LLM_SUPPORTS_VISION.strip().lower() in {"1", "true", "yes", "y", "on"}
+        override = LLM_SUPPORTS_VISION.strip().lower()
+        if override in {"1", "true", "yes", "y", "on"}:
+            return True
+        if override in {"0", "false", "no", "n", "off"}:
+            return False
 
     payload = _ollama_show()
     if not payload:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -143,3 +143,13 @@ def test_max_upload_mb_invalid_falls_back(monkeypatch):
 
     monkeypatch.delenv("MAX_UPLOAD_MB", raising=False)
     importlib.reload(config)
+
+
+def test_llm_supports_vision_blank_normalizes_to_none(monkeypatch):
+    monkeypatch.setenv("LLM_SUPPORTS_VISION", "")
+    cfg = importlib.reload(config)
+    assert cfg.LLM_SUPPORTS_VISION is None
+
+    monkeypatch.setenv("LLM_SUPPORTS_VISION", "   ")
+    cfg = importlib.reload(config)
+    assert cfg.LLM_SUPPORTS_VISION is None

--- a/tests/test_llm_vision_override.py
+++ b/tests/test_llm_vision_override.py
@@ -1,0 +1,40 @@
+from ephemeral import llm_client
+
+
+def _reset_cache():
+    llm_client.model_supports_images.clear()
+
+
+def test_unset_uses_auto_detect(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(llm_client, "LLM_SUPPORTS_VISION", None)
+    monkeypatch.setattr(llm_client, "_ollama_show", lambda: {"capabilities": ["vision"]})
+    assert llm_client.model_supports_images() is True
+
+
+def test_blank_uses_auto_detect(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(llm_client, "LLM_SUPPORTS_VISION", "")
+    monkeypatch.setattr(llm_client, "_ollama_show", lambda: {"capabilities": ["vision"]})
+    assert llm_client.model_supports_images() is True
+
+
+def test_whitespace_only_uses_auto_detect(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(llm_client, "LLM_SUPPORTS_VISION", "   ")
+    monkeypatch.setattr(llm_client, "_ollama_show", lambda: {"capabilities": ["vision"]})
+    assert llm_client.model_supports_images() is True
+
+
+def test_explicit_true_forces_vision(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(llm_client, "LLM_SUPPORTS_VISION", "true")
+    monkeypatch.setattr(llm_client, "_ollama_show", lambda: None)
+    assert llm_client.model_supports_images() is True
+
+
+def test_explicit_false_forces_text_only(monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(llm_client, "LLM_SUPPORTS_VISION", "false")
+    monkeypatch.setattr(llm_client, "_ollama_show", lambda: {"capabilities": ["vision"]})
+    assert llm_client.model_supports_images() is False

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -127,3 +127,11 @@ def test_vision_support_check_uses_current_files_and_history_guard():
     assert '_message_has_image(m.get("content"))' in app_text
     assert "has_image_files or has_image_history" in app_text
     assert "cached_vision" not in app_text
+
+
+def test_text_only_mode_omits_image_parts_from_api_payload():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert 'elif ptype == "image":' in app_text
+    assert 'elif ptype == "image_url":' in app_text
+    assert "if vision_supported:" in app_text
+    assert '{"type": "image_url", "image_url": {"url": f"data:{mime};base64,{img_b64}"}}' in app_text


### PR DESCRIPTION
### Motivation
- Blank or whitespace `LLM_SUPPORTS_VISION` values from `.env.example` and Compose were being treated as explicit overrides, disabling auto-detection and causing the app to wrongly force text-only behavior.
- The goal is to preserve auto-detection when the env var is unset or blank while still allowing explicit truthy/falsy overrides to force vision/text-only modes.

### Description
- Add `_optional_env` helper to normalize unset/blank/whitespace-only env vars to `None` and use it for `LLM_SUPPORTS_VISION` (`ephemeral/config.py`).
- Update `model_supports_images()` parsing to treat only explicit truthy values (`1,true,yes,y,on`) as force-vision and explicit falsy values (`0,false,no,n,off`) as force-text-only, falling back to Ollama metadata otherwise (`ephemeral/llm_client.py`).
- Add unit tests for the new behavior covering unset, blank, whitespace-only, explicit true, and explicit false cases (`tests/test_llm_vision_override.py` and `tests/test_config.py`).
- Add a static contract test ensuring image parts remain gated by `vision_supported` so text-only mode does not send image binaries/URLs to the backend (`tests/test_ui_static_contracts.py`) and update documentation to state that blank/whitespace = auto-detect (`docs/configuration.md`).

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` and it succeeded with no syntax errors.
- Ran `python -m pytest -q` and all tests passed (`83 passed`).
- Ran `python scripts/audit_public_release.py` which reported `No findings`.
- Ran `python scripts/validate_compose_static.py` which passed its checks (compose parsing and service checks reported `PASS`).
- Ran `bash -n scripts/*.sh` and `ruff check .` which completed with no errors and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e7718c2483288eebfb4b3f203e0e)