### PR TITLE
Harden setup wizard validation and remove raw Ollama API toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ GPU support is preserved through the explicit `docker-compose.gpu.yml` override 
 ## Optional shared Ollama API
 
 - Default Compose deployment keeps raw Ollama internal.
-- If you intentionally expose Ollama for shared API use, use compose overrides and network controls.
+- Raw API exposure is a manual opt-in via `docker-compose.api.yml`.
+- Keep `OLLAMA_API_BIND=127.0.0.1` as the safer default when using that override, and widen only intentionally.
 - **Security warning:** exposing raw Ollama does not add app-layer authentication automatically.
 
 ## Development and testing

--- a/docs/setup-wizard.md
+++ b/docs/setup-wizard.md
@@ -19,9 +19,8 @@ It is intended for users who can run commands and prefer profile-driven configur
   - `LLM_MODEL_NAME`
   - `OLLAMA_MODEL_SOURCE`
   - `LLM_CONTEXT_TOKENS` / `OLLAMA_NUM_CTX`
-  - raw Ollama API exposure toggle (default: no)
   - `OLLAMA_NO_CLOUD` privacy toggle (default: yes / `1`)
-- Validates obvious mistakes (numeric port/context, required model fields).
+- Validates obvious mistakes (valid port range `1–65535`, positive integer context size, required model fields).
 - Protects existing `.env` files with overwrite confirmation and timestamped backup.
 - Optionally runs common follow-up commands with explicit per-command confirmation:
   - `docker compose up -d --build`
@@ -45,3 +44,5 @@ python scripts/setup_wizard.py --help
 - The wizard does not make live network calls by itself.
 - Service-start/model-download actions happen only if you approve the optional commands.
 - The midrange profile default uses `qwen3:8b`, which is text-only (not a vision model).
+- Raw Ollama API exposure is a manual, opt-in deployment override using `docker-compose.api.yml`.
+  Keep `OLLAMA_API_BIND=127.0.0.1` as the safer default unless you intentionally need broader access.

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -103,9 +103,21 @@ def prompt_yes_no(label: str, default: bool) -> bool:
 
 
 def validate_positive_int(value: str, field: str) -> str:
-    if not value.isdigit():
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field} must be a positive integer.")
+    if not stripped.isdigit():
         raise ValueError(f"{field} must be numeric.")
-    return value
+    if int(stripped) <= 0:
+        raise ValueError(f"{field} must be greater than zero.")
+    return stripped
+
+
+def validate_port(value: str, field: str = "App port") -> str:
+    validated = validate_positive_int(value, field)
+    if int(validated) > 65535:
+        raise ValueError(f"{field} must be between 1 and 65535.")
+    return validated
 
 
 def backup_existing_env(env_path: Path) -> Path:
@@ -166,16 +178,11 @@ def main() -> int:
         print("Starting from empty values for custom/manual profile.")
 
     env_values["APP_DISPLAY_NAME"] = prompt_text("App display name", env_values.get("APP_DISPLAY_NAME", "EphemerAI"), required=True)
-    env_values["APP_PORT"] = validate_positive_int(prompt_text("App port", env_values.get("APP_PORT", "8501"), required=True), "App port")
+    env_values["APP_PORT"] = validate_port(prompt_text("App port", env_values.get("APP_PORT", "8501"), required=True), "App port")
     env_values["LLM_MODEL_NAME"] = prompt_text("Model alias name", env_values.get("LLM_MODEL_NAME", "ephemeral-default"), required=True)
     env_values["OLLAMA_MODEL_SOURCE"] = prompt_text("Model source tag", env_values.get("OLLAMA_MODEL_SOURCE", "qwen3:8b"), required=True)
     env_values["LLM_CONTEXT_TOKENS"] = validate_positive_int(prompt_text("Context size", env_values.get("LLM_CONTEXT_TOKENS", "32768"), required=True), "Context size")
     env_values["OLLAMA_NUM_CTX"] = env_values["LLM_CONTEXT_TOKENS"]
-
-    expose_raw = prompt_yes_no("Expose raw Ollama API externally?", default=False)
-    if expose_raw:
-        print("WARNING: Exposing raw Ollama API can allow unauthenticated access if network controls are weak.")
-    env_values["EXPOSE_RAW_OLLAMA_API"] = "1" if expose_raw else "0"
 
     no_cloud = prompt_yes_no("Keep Ollama cloud features disabled (OLLAMA_NO_CLOUD=1)?", default=True)
     if not no_cloud:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,12 +1,10 @@
 from pathlib import Path
+import sys
 
 import pytest
 
-from scripts.setup_wizard import (
-    choose_default_profile,
-    parse_env_template,
-    validate_positive_int,
-)
+import scripts.setup_wizard as setup_wizard
+from scripts.setup_wizard import choose_default_profile, parse_env_template, validate_port, validate_positive_int
 
 
 def test_parse_env_template_reads_key_values(tmp_path: Path) -> None:
@@ -30,7 +28,61 @@ def test_validate_positive_int_accepts_digits() -> None:
     assert validate_positive_int("8501", "App port") == "8501"
 
 
-@pytest.mark.parametrize("value", ["", "abc", "85a"])
+@pytest.mark.parametrize("value", ["", "abc", "85a", "0", "-1"])
 def test_validate_positive_int_rejects_non_numeric(value: str) -> None:
     with pytest.raises(ValueError):
         validate_positive_int(value, "Context size")
+
+
+@pytest.mark.parametrize("value", ["0", "65536", "abc"])
+def test_validate_port_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        validate_port(value)
+
+
+def test_validate_port_accepts_valid_port() -> None:
+    assert validate_port("8501") == "8501"
+
+
+def test_wizard_output_excludes_raw_api_flag_and_keeps_no_cloud_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "examples" / "profiles").mkdir(parents=True)
+    (tmp_path / "examples" / "profiles" / "low-end-laptop.env").write_text("APP_DISPLAY_NAME=EphemerAI\n", encoding="utf-8")
+    (tmp_path / "examples" / "profiles" / "midrange-gpu.env").write_text("APP_DISPLAY_NAME=EphemerAI\n", encoding="utf-8")
+    (tmp_path / "examples" / "profiles" / "high-vram-workstation.env").write_text("APP_DISPLAY_NAME=EphemerAI\n", encoding="utf-8")
+    monkeypatch.setattr(setup_wizard, "PROFILE_DIR", tmp_path / "examples" / "profiles")
+    monkeypatch.setattr(setup_wizard, "detect_platform", lambda: {"system": "linux", "release": "test", "in_wsl": False, "in_powershell": False, "shell": "bash"})
+    monkeypatch.setattr(setup_wizard, "command_exists", lambda _cmd: False)
+    monkeypatch.setattr(setup_wizard, "detect_nvidia", lambda: (False, "none"))
+    monkeypatch.setattr(setup_wizard.subprocess, "run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sys, "argv", ["setup_wizard.py"])
+
+    answers = iter(["", "", "", "", "", "", "", "n", "n", "n"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    assert setup_wizard.main() == 0
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "EXPOSE_RAW_OLLAMA_API" not in env_text
+    assert "OLLAMA_NO_CLOUD=1" in env_text
+
+
+def test_wizard_existing_env_backup_behavior(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("APP_DISPLAY_NAME=OldName\n", encoding="utf-8")
+    (tmp_path / "examples" / "profiles").mkdir(parents=True)
+    for name in ("low-end-laptop.env", "midrange-gpu.env", "high-vram-workstation.env"):
+        (tmp_path / "examples" / "profiles" / name).write_text("APP_DISPLAY_NAME=EphemerAI\n", encoding="utf-8")
+    monkeypatch.setattr(setup_wizard, "PROFILE_DIR", tmp_path / "examples" / "profiles")
+    monkeypatch.setattr(setup_wizard, "detect_platform", lambda: {"system": "linux", "release": "test", "in_wsl": False, "in_powershell": False, "shell": "bash"})
+    monkeypatch.setattr(setup_wizard, "command_exists", lambda _cmd: False)
+    monkeypatch.setattr(setup_wizard, "detect_nvidia", lambda: (False, "none"))
+    monkeypatch.setattr(setup_wizard.subprocess, "run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(sys, "argv", ["setup_wizard.py"])
+
+    answers = iter(["", "", "", "", "", "", "", "y", "n", "n", "n"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    assert setup_wizard.main() == 0
+    backups = list(tmp_path.glob(".env.*.bak"))
+    assert backups, "Expected a backup file for pre-existing .env"
+    assert backups[0].read_text(encoding="utf-8") == "APP_DISPLAY_NAME=OldName\n"


### PR DESCRIPTION
### Motivation
- The interactive setup wizard exposed a misleading "Expose raw Ollama API" toggle and wrote `EXPOSE_RAW_OLLAMA_API` into generated `.env` files even though the real opt-in is the compose override `docker-compose.api.yml`/`OLLAMA_API_BIND` and no code consumes that variable.  This is a security/UX risk. 
- Numeric validation was weak: `validate_positive_int()` accepted `0` and allowed non-positive values for ports, context size, and upload limits, which can produce invalid configuration.

### Description
- Removed the interactive raw Ollama exposure prompt and stopped writing `EXPOSE_RAW_OLLAMA_API` from `scripts/setup_wizard.py`, so generated `.env` files no longer contain that unused flag and raw API exposure remains a manual opt-in via `docker-compose.api.yml`.
- Hardened validators in `scripts/setup_wizard.py`: `validate_positive_int()` now rejects empty, non-numeric, zero, and negative values, and a new `validate_port()` enforces `1..65535` and is applied to `APP_PORT`.
- Preserved existing safe defaults and safety behaviors: `OLLAMA_NO_CLOUD=1` remains the default, `.env` overwrite protection and timestamped backups are unchanged, and no compose/runtime behavior was altered.
- Documentation updates: removed the wizard toggle reference and added guidance that raw Ollama API exposure is a manual opt-in via `docker-compose.api.yml` and that `OLLAMA_API_BIND=127.0.0.1` is the safer default in `docs/setup-wizard.md` and `README.md`.
- Tests updated/added in `tests/test_setup_wizard.py` to cover `validate_positive_int()` rejecting `0`/negative/empty/non-numeric, `validate_port()` range checks, that generated `.env` output does not contain `EXPOSE_RAW_OLLAMA_API`, backup behavior for existing `.env`, and preservation of `OLLAMA_NO_CLOUD=1`.

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` and it succeeded.
- Ran `python -m pytest -q` and all tests passed (`96 passed`).
- Ran repository checks `python scripts/audit_public_release.py` (no findings) and `python scripts/validate_compose_static.py` (compose checks passed).
- Ran shell linting `bash -n scripts/*.sh` and `ruff check .` with no failures.
- Performed a repository search to verify removal of the stale toggle and update references; results show `EXPOSE_RAW_OLLAMA_API` removed from wizard output and docs updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f5ea51908328a8238b7d7484a18a)