### PR TITLE
Harden create_ollama_model dotenv handling and add dry-run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For image support on any tier, choose a **vision-capable model** and verify capa
 
 See [`docs/configuration.md`](docs/configuration.md).
 
-Use `.env` (copied from `.env.example`) as the main configuration surface for deployment customization. Normal deployment customization should be done through config values, not source edits.
+Use `.env` (copied from `.env.example`) as the main configuration surface for deployment customization. Normal deployment customization should be done through config values, not source edits. `.env` is parsed as standard dotenv-style `KEY=VALUE` text (including values with spaces); it does not need to be shell-source-safe.
 
 ## Model profiles
 

--- a/tests/test_create_ollama_model_script.py
+++ b/tests/test_create_ollama_model_script.py
@@ -20,6 +20,18 @@ def _run_dry_run() -> subprocess.CompletedProcess[str]:
     )
 
 
+def _with_temp_env(contents: str) -> subprocess.CompletedProcess[str]:
+    original = ENV_FILE.read_text(encoding="utf-8") if ENV_FILE.exists() else None
+    try:
+        ENV_FILE.write_text(contents, encoding="utf-8")
+        return _run_dry_run()
+    finally:
+        if original is None:
+            ENV_FILE.unlink(missing_ok=True)
+        else:
+            ENV_FILE.write_text(original, encoding="utf-8")
+
+
 def test_create_ollama_model_dry_run_without_env() -> None:
     original = ENV_FILE.read_text(encoding="utf-8") if ENV_FILE.exists() else None
     try:
@@ -48,15 +60,53 @@ def test_create_ollama_model_dry_run_accepts_env_example() -> None:
             ENV_FILE.write_text(original, encoding="utf-8")
 
 
-def test_create_ollama_model_dry_run_accepts_profile_env() -> None:
+def test_create_ollama_model_dry_run_accepts_all_profile_envs() -> None:
+    profile_paths = [
+        ROOT / "examples/profiles/midrange-gpu.env",
+        ROOT / "examples/profiles/low-end-laptop.env",
+        ROOT / "examples/profiles/high-vram-workstation.env",
+    ]
     original = ENV_FILE.read_text(encoding="utf-8") if ENV_FILE.exists() else None
     try:
-        shutil.copyfile(ROOT / "examples/profiles/midrange-gpu.env", ENV_FILE)
-        result = _run_dry_run()
-        assert result.returncode == 0, result.stderr
-        assert "Dry run enabled. No commands will be executed." in result.stdout
+        for profile_path in profile_paths:
+            shutil.copyfile(profile_path, ENV_FILE)
+            result = _run_dry_run()
+            assert result.returncode == 0, f"{profile_path}: {result.stderr}"
+            assert "Dry run enabled. No commands will be executed." in result.stdout
     finally:
         if original is None:
             ENV_FILE.unlink(missing_ok=True)
         else:
             ENV_FILE.write_text(original, encoding="utf-8")
+
+
+def test_create_ollama_model_dry_run_accepts_spaced_values_and_ignores_unknown_keys() -> None:
+    result = _with_temp_env(
+        "\n".join(
+            [
+                "# normal dotenv with spaces",
+                "OLLAMA_CONTAINER=ollama",
+                "OLLAMA_MODEL_SOURCE='qwen3:8b'",
+                "LLM_MODEL_NAME=ephemeral-default",
+                "OLLAMA_TEMPERATURE=0.7",
+                "OLLAMA_TOP_P=0.8",
+                "OLLAMA_TOP_K=20",
+                "OLLAMA_MIN_P=0",
+                "OLLAMA_REPEAT_PENALTY=1.0",
+                "UNUSED_PUBLIC_TEXT=Upload files and chat locally with your documents.",
+                "UNUSED_SHELL_CODE=$(echo should-not-run)",
+                "",
+            ]
+        )
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Dry run enabled. No commands will be executed." in result.stdout
+    assert "OLLAMA_MODEL_SOURCE=qwen3:8b" in result.stdout
+    assert "UNUSED_PUBLIC_TEXT" not in result.stdout
+    assert "should-not-run" not in result.stdout
+
+
+def test_create_ollama_model_script_does_not_source_env() -> None:
+    content = SCRIPT.read_text(encoding="utf-8")
+    assert "source .env" not in content
+    assert ". .env" not in content


### PR DESCRIPTION
### Motivation
- Prevent unsafe execution of arbitrary `.env` content by avoiding `source .env` and parsing dotenv files safely instead. 
- Ensure first-time user flows (copying `.env.example`) and profile env files with spaces in values work reliably. 
- Narrow the script import surface to only the variables the model creation flow actually needs so unknown keys or shell-like content are ignored while preserving `--dry-run` safety.

### Description
- Implemented safe dotenv parsing in the create model workflow to accept `KEY=VALUE` lines, ignore blank/comment lines, accept optional single/double quotes around values, preserve spaces, and avoid executing shell syntax (parsing logic lives in the script via `read_dotenv_value`/`load_selected_dotenv` and exports only allowed keys). 
- Added and extended tests in `tests/test_create_ollama_model_script.py` to cover: dry-run behavior with no `.env`, `.env.example`, and all profile envs, handling of spaced values, ignoring unknown keys, ensuring shell-like values are not executed, and asserting the script does not contain `source .env` or `. .env`. 
- Updated `README.md` configuration section to state that `.env` is parsed as standard dotenv-style `KEY=VALUE` text (including values with spaces) and does not need to be shell-source-safe.

### Testing
- Ran `bash scripts/create_ollama_model.sh --dry-run` with no `.env`, with `cp .env.example .env`, and with each profile (`examples/profiles/*`), and all dry-run invocations completed successfully. 
- Ran the test suite with `python -m pytest -q` which completed with `98 passed`. 
- Validated code formatting and static checks via `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py`, `python scripts/audit_public_release.py`, `python scripts/validate_compose_static.py`, `bash -n scripts/*.sh`, and `ruff check .`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f7c106a08328a6d6f836522badc6)