### PR TITLE
Configure Streamlit maxUploadSize at runtime via MAX_UPLOAD_MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,26 +13,16 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # --- Application code --------------------------------------------
 COPY . .
-# --- Streamlit config --------------------------------------------
-RUN mkdir -p .streamlit && \
-    printf '%s\n' \
-        '[server]' \
-        'headless = true' \
-        'enableCORS = false' \
-        'enableXsrfProtection = false' \
-        'maxUploadSize = 50' \
-        'port = 8501' \
-        'address = "0.0.0.0"' \
-        '' \
-        '[browser]' \
-        'serverAddress     = "0.0.0.0"' \
-        'serverPort        = 8501' \
-        'gatherUsageStats  = false' \
-        '' > .streamlit/config.server.toml && \
-    cat .streamlit/config.server.toml .streamlit/config.toml > .streamlit/config.toml.merged && \
-    mv .streamlit/config.toml.merged .streamlit/config.toml && \
-    rm .streamlit/config.server.toml
 
 EXPOSE 8501
 
-CMD ["streamlit", "run", "ephemeral_app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+CMD streamlit run ephemeral_app.py \
+    --server.port=8501 \
+    --server.address=0.0.0.0 \
+    --server.headless=true \
+    --server.enableCORS=false \
+    --server.enableXsrfProtection=false \
+    --server.maxUploadSize="${MAX_UPLOAD_MB:-50}" \
+    --browser.serverAddress=0.0.0.0 \
+    --browser.serverPort=8501 \
+    --browser.gatherUsageStats=false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,8 @@ Exposing raw Ollama on the network is optional and should be deliberate: direct 
 
 ## Environment variables (.env.example)
 
+`MAX_UPLOAD_MB` is the single user-facing upload limit: it is enforced by the app upload guardrails and passed to the Dockerized Streamlit server runtime upload cap. Very large files can still fail due to browser limits, Apache Tika parsing/memory constraints, or model context/token budgeting limits.
+
 | Option | Default | Required? | Valid values/range | What it does | When to change it |
 |---|---|---|---|---|---|
 | `APP_DISPLAY_NAME` | `EphemerAI` | No | Non-empty string | Main app brand name in UI. | Change for your organization/product branding. |
@@ -40,7 +42,7 @@ Exposing raw Ollama on the network is optional and should be deliberate: direct 
 | `APP_LOGO_PATH` | `static/ephemeral_logo.png` | No | Path to local asset | Path to logo asset served by app. | Change when using custom logo. |
 | `APP_EXPORT_TITLE` | `EphemerAI Conversation Export` | No | String | Title used in exported conversations. | Rebrand exports or compliance labeling. |
 | `SYSTEM_PROMPT_PATH` | `system_prompt_template.md` | No | Path to readable prompt template file | System prompt template file loaded by app. | Use a custom prompt policy/template. |
-| `MAX_UPLOAD_MB` | `50` | No | Positive integer MB (practical range depends on host resources) | Max per-file upload size guardrail. | Raise/lower upload limit for capacity/risk policy. |
+| `MAX_UPLOAD_MB` | `50` | No | Positive integer MB (practical range depends on host resources) | Max per-file upload size guardrail in the app and Dockerized Streamlit server runtime. | Raise/lower upload limit for capacity/risk policy. |
 | `DEFAULT_UPLOAD_PROMPT` | `Summarize the key points from the uploaded document.` | No | String | Default prompt inserted for document analysis flows. | Change default task framing for users. |
 | `EPHEMERAL_DEBUG` | `false` | No | `true`/`false` | Enables debug behavior/log verbosity intended for troubleshooting. | Temporary debugging only. |
 | `EPHEMERAL_TIMEZONE` | _(empty)_ | No | IANA timezone (for example `America/New_York`) or empty | Optional timezone override for app behavior that needs timezone context. | Set for deterministic time display/ops behavior. |

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -135,3 +135,11 @@ def test_text_only_mode_omits_image_parts_from_api_payload():
     assert 'elif ptype == "image_url":' in app_text
     assert "if vision_supported:" in app_text
     assert '{"type": "image_url", "image_url": {"url": f"data:{mime};base64,{img_b64}"}}' in app_text
+
+
+def test_dockerfile_upload_size_uses_runtime_env_and_no_hardcoded_50():
+    dockerfile_text = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    assert 'maxUploadSize = 50' not in dockerfile_text
+    assert '--server.maxUploadSize="${MAX_UPLOAD_MB:-50}"' in dockerfile_text
+    assert 'CMD ["streamlit", "run"' not in dockerfile_text
+


### PR DESCRIPTION
### Motivation
- Ensure `MAX_UPLOAD_MB` is the single user-facing upload-size limit and avoid a mismatch where an image baked at build time enforced a different server limit.
- Prevent future regressions where `maxUploadSize = 50` is hardcoded into the image and cannot be overridden by environment variables at container runtime.

### Description
- Removed build-time generation of a `.streamlit` server config that hardcoded `maxUploadSize = 50` from the `Dockerfile` and stopped merging it into tracked theme config.
- Replaced JSON-array `CMD` with a shell-form `CMD` that launches Streamlit and passes `--server.maxUploadSize="${MAX_UPLOAD_MB:-50}"` so the value expands at container runtime.
- Preserved prior Streamlit options (port/address/headless/CORS/XSRF/browser flags) via equivalent CLI flags so runtime behavior is unchanged.
- Updated `docs/configuration.md` to state that `MAX_UPLOAD_MB` controls both the app upload guardrail and the Dockerized Streamlit server cap, and added a static contract test `test_dockerfile_upload_size_uses_runtime_env_and_no_hardcoded_50` to prevent regressions.

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` and it succeeded with no syntax errors.
- Ran `python -m pytest -q` and the test suite passed (`99 passed`).
- Ran `python scripts/audit_public_release.py` and `python scripts/validate_compose_static.py` and both completed with passing checks/no findings.
- Ran `bash -n scripts/*.sh`, `ruff check .`, and `rg -n "maxUploadSize|server.maxUploadSize|MAX_UPLOAD_MB|streamlit run|CMD|ENTRYPOINT" ...` checks, all of which succeeded and showed the updated Dockerfile, docs, and new test; the added test verifies no hardcoded `maxUploadSize = 50` and that the runtime env expansion is present.
- Docker image build/run validation was skipped because the Docker CLI is not available in this environment (SKIPPED: Docker CLI unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f414d12c40832889de06eb5e2f45c7)