### PR TITLE
Improve bootstrap scripts: safe dry-run, non-interactive env creation, and PowerShell contract tests

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -6,8 +6,8 @@ Use these scripts for a safe, one-command first run. They validate prerequisites
 
 1. Checks Docker + Docker Compose.
 2. Checks Git and Python availability.
-3. Optionally runs `scripts/setup_wizard.py` when `.env` is missing.
-4. Otherwise copies `.env.example` to `.env` and prompts you to review values.
+3. In interactive mode, optionally runs `scripts/setup_wizard.py` when `.env` is missing.
+4. In non-interactive mode (`--yes` / `-Yes`), creates `.env` from `.env.example` safe defaults when missing.
 5. Runs `docker compose up -d --build` (CPU-safe default).
 6. Runs `scripts/create_ollama_model.sh`.
 7. Runs `python scripts/doctor.py`.
@@ -19,6 +19,7 @@ Notes:
 - Codex web/cloud execution environments may not include the Docker CLI.
 - For Compose-related changes, run Docker Compose validation locally or in GitHub Actions before merging.
 - `python scripts/validate_compose_static.py` is the Docker-free fallback validator.
+- When PowerShell is unavailable in CI/Codex, validate `scripts/bootstrap.ps1` with static contract tests (no `pwsh` runtime required).
 
 ## Linux / macOS / WSL
 
@@ -28,7 +29,7 @@ From repository root:
 bash scripts/bootstrap.sh
 ```
 
-Preview actions without changing anything:
+Preview actions without changing anything (side-effect-free; does not create `.env`, start containers, or create Ollama models):
 
 ```bash
 bash scripts/bootstrap.sh --dry-run
@@ -40,7 +41,7 @@ Show options:
 bash scripts/bootstrap.sh --help
 ```
 
-Non-interactive mode:
+Non-interactive mode (skips setup wizard prompts; creates `.env` from safe defaults if missing):
 
 ```bash
 bash scripts/bootstrap.sh --yes
@@ -54,7 +55,7 @@ From repository root in PowerShell:
 powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1
 ```
 
-Preview actions without changing anything:
+Preview actions without changing anything (side-effect-free; does not create `.env`, start containers, or create Ollama models):
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1 -DryRun
@@ -66,7 +67,7 @@ Show options:
 powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1 -Help
 ```
 
-Non-interactive mode:
+Non-interactive mode (skips setup wizard prompts; creates `.env` from safe defaults if missing):
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap.ps1 -Yes

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -46,11 +46,25 @@ Say "  3) Run docker compose up -d --build"
 Say "  4) Run scripts/create_ollama_model.sh"
 Say "  5) Run python scripts/doctor.py"
 
+$dockerReady = $false
 $dockerCmd = Get-Command docker -ErrorAction SilentlyContinue
-if (-not $dockerCmd) { Fail 'Docker is not installed or not on PATH.' }
-try { & docker info *> $null } catch { Fail 'Docker is installed but not running. Start Docker Desktop and retry.' }
-try { & docker compose version *> $null } catch { Fail 'Docker Compose (docker compose) is unavailable.' }
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) { Fail 'Git is not installed or not on PATH.' }
+if (-not $dockerCmd) {
+  if ($DryRun) { Warn 'Docker is unavailable (dry-run continues).' }
+  else { Fail 'Docker is not installed or not on PATH.' }
+} else {
+  if ($DryRun) {
+    try { & docker info *> $null; & docker compose version *> $null; $dockerReady = $true; Say '[dry-run] Docker CLI and Compose are available.' }
+    catch { Warn 'Docker/Compose check would fail in a real run (dry-run continues).' }
+  } else {
+    try { & docker info *> $null } catch { Fail 'Docker is installed but not running. Start Docker Desktop and retry.' }
+    try { & docker compose version *> $null } catch { Fail 'Docker Compose (docker compose) is unavailable.' }
+    $dockerReady = $true
+  }
+}
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+  if ($DryRun) { Warn 'Git is unavailable (dry-run continues).' }
+  else { Fail 'Git is not installed or not on PATH.' }
+}
 
 $pythonCmd = $null
 if (Get-Command python -ErrorAction SilentlyContinue) { $pythonCmd = 'python' }
@@ -58,13 +72,18 @@ elseif (Get-Command py -ErrorAction SilentlyContinue) { $pythonCmd = 'py'; }
 else { Warn 'Python was not found. setup_wizard.py and doctor.py cannot run.' }
 
 if (-not (Test-Path '.env')) {
-  if ($pythonCmd -and (Confirm-Step '.env is missing. Run guided setup wizard now?')) {
+  if ($DryRun) {
+    Say '[dry-run] Would prepare .env from defaults (.env.example or profile).'
+  } elseif ($Yes) {
+    if (-not (Test-Path '.env.example')) { Fail '.env.example was not found, cannot create .env.' }
+    Copy-Item '.env.example' '.env'
+    Say 'Created .env from .env.example using safe defaults. Please review and adjust .env for your environment.'
+  } elseif ($pythonCmd -and (Confirm-Step '.env is missing. Run guided setup wizard now?')) {
     if ($pythonCmd -eq 'py') { Run-Step 'py' @('-3','scripts/setup_wizard.py') }
     else { Run-Step $pythonCmd @('scripts/setup_wizard.py') }
   } else {
     if (-not (Test-Path '.env.example')) { Fail '.env.example was not found, cannot create .env.' }
-    if ($DryRun) { Say '[dry-run] Copy-Item .env.example .env' }
-    else { Copy-Item '.env.example' '.env' }
+    Copy-Item '.env.example' '.env'
     Say 'Created .env from .env.example. Please review and adjust .env for your environment.'
   }
 }
@@ -77,14 +96,21 @@ if ((Test-Path '.env') -and ((Get-Content '.env' | Select-String -Pattern '^\s*O
   }
 }
 
-Run-Step 'docker' @('compose','up','-d','--build')
+if ($dockerReady) {
+  Run-Step 'docker' @('compose','up','-d','--build')
 
-if (Get-Command bash -ErrorAction SilentlyContinue) {
-  Run-Step 'bash' @('scripts/create_ollama_model.sh')
-} elseif (Get-Command wsl -ErrorAction SilentlyContinue) {
-  Run-Step 'wsl' @('bash','-lc','cd "' + $repoRoot + '" && bash scripts/create_ollama_model.sh')
+  if (Get-Command bash -ErrorAction SilentlyContinue) {
+    Run-Step 'bash' @('scripts/create_ollama_model.sh')
+  } elseif (Get-Command wsl -ErrorAction SilentlyContinue) {
+    Run-Step 'wsl' @('bash','-lc','cd "' + $repoRoot + '" && bash scripts/create_ollama_model.sh')
+  } elseif (-not $DryRun) {
+    Fail 'Could not run scripts/create_ollama_model.sh. Install Git Bash or enable WSL.'
+  }
+} elseif ($DryRun) {
+  Say '[dry-run] Would run docker compose up -d --build.'
+  Say '[dry-run] Would run scripts/create_ollama_model.sh.'
 } else {
-  Fail 'Could not run scripts/create_ollama_model.sh. Install Git Bash or enable WSL.'
+  Fail 'Docker is required for non-dry-run bootstrap.'
 }
 
 if (-not $pythonCmd) {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -58,6 +58,10 @@ confirm() {
 check_cmd() {
   local bin="$1" label="$2"
   if ! command -v "$bin" >/dev/null 2>&1; then
+    if [[ "$DRY_RUN" == true ]]; then
+      warn "$label is unavailable (dry-run continues)."
+      return 1
+    fi
     fail "$label is not installed or not on PATH."
   fi
 }
@@ -69,14 +73,26 @@ say "  3) Run docker compose up -d --build"
 say "  4) Run scripts/create_ollama_model.sh"
 say "  5) Run python scripts/doctor.py"
 
-check_cmd docker "Docker"
-if ! docker info >/dev/null 2>&1; then
-  fail "Docker is installed but not running. Start Docker and try again."
+DOCKER_READY=false
+if check_cmd docker "Docker"; then
+  if [[ "$DRY_RUN" == true ]]; then
+    if docker info >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+      DOCKER_READY=true
+      say "[dry-run] Docker CLI and Compose are available."
+    else
+      warn "Docker/Compose check would fail in a real run (dry-run continues)."
+    fi
+  else
+    if ! docker info >/dev/null 2>&1; then
+      fail "Docker is installed but not running. Start Docker and try again."
+    fi
+    if ! docker compose version >/dev/null 2>&1; then
+      fail "Docker Compose (docker compose) is unavailable. Install/enable Compose v2."
+    fi
+    DOCKER_READY=true
+  fi
 fi
-if ! docker compose version >/dev/null 2>&1; then
-  fail "Docker Compose (docker compose) is unavailable. Install/enable Compose v2."
-fi
-check_cmd git "Git"
+check_cmd git "Git" >/dev/null 2>&1 || true
 
 PYTHON_BIN=""
 if command -v python3 >/dev/null 2>&1; then
@@ -96,7 +112,13 @@ if [[ "${OSTYPE:-}" == linux* ]] || grep -qi microsoft /proc/version 2>/dev/null
 fi
 
 if [[ ! -f .env ]]; then
-  if [[ -n "$PYTHON_BIN" ]] && confirm ".env is missing. Run guided setup wizard now?"; then
+  if [[ "$DRY_RUN" == true ]]; then
+    say "[dry-run] Would prepare .env from defaults (.env.example or profile)."
+  elif [[ "$ASSUME_YES" == true ]]; then
+    [[ -f .env.example ]] || fail ".env.example was not found, cannot create .env."
+    cp .env.example .env
+    say "Created .env from .env.example using safe defaults. Please review and adjust .env for your environment."
+  elif [[ -n "$PYTHON_BIN" ]] && confirm ".env is missing. Run guided setup wizard now?"; then
     run_cmd "$PYTHON_BIN" scripts/setup_wizard.py
   else
     [[ -f .env.example ]] || fail ".env.example was not found, cannot create .env."
@@ -105,8 +127,15 @@ if [[ ! -f .env ]]; then
   fi
 fi
 
-run_cmd docker compose up -d --build
-run_cmd bash scripts/create_ollama_model.sh
+if [[ "$DOCKER_READY" == true ]]; then
+  run_cmd docker compose up -d --build
+  run_cmd bash scripts/create_ollama_model.sh
+elif [[ "$DRY_RUN" == true ]]; then
+  say "[dry-run] Would run docker compose up -d --build."
+  say "[dry-run] Would run scripts/create_ollama_model.sh."
+else
+  fail "Docker is required for non-dry-run bootstrap."
+fi
 
 if [[ -z "$PYTHON_BIN" ]]; then
   warn "Skipping doctor check because Python is unavailable."

--- a/tests/test_bootstrap_powershell_contracts.py
+++ b/tests/test_bootstrap_powershell_contracts.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+
+BOOTSTRAP_PS1 = Path('scripts/bootstrap.ps1')
+
+
+def _script_text() -> str:
+    return BOOTSTRAP_PS1.read_text(encoding='utf-8')
+
+
+def test_ps1_defines_dryrun_and_yes_parameters() -> None:
+    text = _script_text()
+    assert '[switch]$DryRun' in text
+    assert '[switch]$Yes' in text
+
+
+def test_ps1_dry_run_has_planned_actions_path() -> None:
+    text = _script_text()
+    assert '[dry-run]' in text
+    assert "Would run docker compose up -d --build." in text
+    assert "Would run scripts/create_ollama_model.sh." in text
+
+
+def test_ps1_dry_run_does_not_require_docker_installed() -> None:
+    text = _script_text()
+    assert "if (-not $dockerCmd)" in text
+    assert "if ($DryRun) { Warn 'Docker is unavailable (dry-run continues).' }" in text
+
+
+def test_ps1_yes_mode_skips_setup_wizard_and_uses_env_example_defaults() -> None:
+    text = _script_text()
+    yes_branch = "elseif ($Yes)"
+    assert yes_branch in text
+    # contract: -Yes path creates .env from defaults and does not invoke setup_wizard
+    yes_block_start = text.index(yes_branch)
+    wizard_ref = text.find('setup_wizard.py', yes_block_start, yes_block_start + 400)
+    assert wizard_ref == -1
+    assert "Copy-Item '.env.example' '.env'" in text
+
+
+def test_ps1_keeps_raw_ollama_internal_by_default() -> None:
+    text = _script_text()
+    assert 'EXPOSE_RAW_OLLAMA_API' not in text
+    assert 'docker-compose.api.yml' not in text
+
+
+def test_ps1_mentions_safe_defaults_and_no_driver_installers() -> None:
+    text = _script_text()
+    assert '.env.example' in text
+    forbidden = ['apt-get', 'yum', 'brew install', 'choco install', 'winget install', 'nvidia-driver']
+    assert not any(token in text for token in forbidden)

--- a/tests/test_bootstrap_script.py
+++ b/tests/test_bootstrap_script.py
@@ -1,0 +1,82 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_exec(path: Path) -> None:
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR)
+
+
+def _make_fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    source_bootstrap = Path("/workspace/EphemerAl/scripts/bootstrap.sh").read_text(encoding="utf-8")
+    _write(scripts_dir / "bootstrap.sh", source_bootstrap)
+    _make_exec(scripts_dir / "bootstrap.sh")
+
+    _write(repo / ".env.example", "OLLAMA_NO_CLOUD=1\n")
+    _write(scripts_dir / "setup_wizard.py", "raise SystemExit('wizard should not run in this test')\n")
+    _write(scripts_dir / "doctor.py", "print('doctor-ok')\n")
+    _write(scripts_dir / "create_ollama_model.sh", "#!/usr/bin/env bash\necho model-script\n")
+    _make_exec(scripts_dir / "create_ollama_model.sh")
+    return repo
+
+
+def test_bootstrap_dry_run_without_docker_does_not_create_env(tmp_path: Path) -> None:
+    repo = _make_fixture_repo(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = "/usr/bin:/bin"  # likely excludes docker in test env
+
+    result = subprocess.run(
+        ["bash", "scripts/bootstrap.sh", "--dry-run"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (repo / ".env").exists()
+    assert "[dry-run]" in result.stdout
+
+
+def test_bootstrap_yes_creates_env_without_wizard(tmp_path: Path) -> None:
+    repo = _make_fixture_repo(tmp_path)
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    docker = fakebin / "docker"
+    docker.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$1\" == \"info\" ]]; then exit 0; fi\n"
+        "if [[ \"$1\" == \"compose\" && \"$2\" == \"version\" ]]; then exit 0; fi\n"
+        "if [[ \"$1\" == \"compose\" ]]; then exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    _make_exec(docker)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fakebin}:{env['PATH']}"
+
+    result = subprocess.run(
+        ["bash", "scripts/bootstrap.sh", "--yes"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    created_env = (repo / ".env").read_text(encoding="utf-8")
+    assert "OLLAMA_NO_CLOUD=1" in created_env
+    assert "Created .env from .env.example" in result.stdout
+    assert "setup_wizard.py" not in result.stdout


### PR DESCRIPTION
### Motivation

- Make the bootstrap flow safer and CI-friendly by allowing side-effect-free `dry-run` execution even when Docker/Git are not present.  
- Support a non-interactive mode that can create a `.env` from safe defaults so unattended setups (CI or scripts) can proceed.  
- Add static contract tests for PowerShell bootstrap behavior to validate command-line switches and dry-run/yes semantics without requiring `pwsh` in CI.

### Description

- Updated documentation `docs/bootstrap.md` to clarify `--dry-run` semantics, describe the non-interactive `--yes` behavior, and mention static validation for PowerShell when `pwsh` is unavailable.  
- Enhanced `scripts/bootstrap.sh` to detect `--dry-run` and `--yes` (`ASSUME_YES`) modes, avoid failing when Docker/Git are missing in `dry-run`, set a `DOCKER_READY` flag, create `.env` from `.env.example` in `--yes` mode, and guard running `docker compose`/model-creation behind `DOCKER_READY`.  
- Enhanced `scripts/bootstrap.ps1` with analogous behavior for `-DryRun` and `-Yes`, improved Docker/Git/Python checks in dry-run mode, automatic `.env` creation from `.env.example` in `-Yes`, and clearer error/warn messages when actions cannot be executed.  
- Added tests `tests/test_bootstrap_powershell_contracts.py` to assert PowerShell script contracts and `tests/test_bootstrap_script.py` to exercise shell script `--dry-run` and `--yes` behaviors in a temporary repo fixture.

### Testing

- Ran the test suite with `pytest -q` including the two new tests, and both `tests/test_bootstrap_powershell_contracts.py` and `tests/test_bootstrap_script.py` passed.  
- Verified `bash scripts/bootstrap.sh --dry-run` produces planned-action output without creating `.env` in a simulated environment in the new test.  
- Verified `bash scripts/bootstrap.sh --yes` creates `.env` from `.env.example` and does not invoke the setup wizard in the new test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41785966083289d9bd50802881fb4)