### PR TITLE
Docs: add recommended bootstrap quickstart, reorder manual setup, and add bind-address warnings; update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,38 @@ Set expectations first:
 - Document uploads work with the default profile.
 - Image analysis requires a **vision-capable model** and (if auto-detection is insufficient) setting `LLM_SUPPORTS_VISION` appropriately.
 
-Then:
+### A) Recommended bootstrap path (shortest)
 
-1. **Pick a profile** from [`docs/model-profiles.md`](docs/model-profiles.md).
-2. **Choose Compose mode**:
+```bash
+bash scripts/bootstrap.sh
+```
+
+Bootstrap handles `.env` setup, starts the Compose stack, creates the local Ollama alias, and runs doctor checks.
+
+### B) Manual path (explicit order)
+
+1. **Prepare `.env` (choose one):**
+   - `cp .env.example .env`, or
+   - `cp examples/profiles/midrange-gpu.env .env` (or another profile from `examples/profiles/`), or
+   - `python scripts/setup_wizard.py`
+2. **Review `.env` values** (model tag/alias, ports, bind addresses, context).
+3. **Start services:**
    - CPU/low-end (default): `docker compose up -d --build`
    - GPU/high-VRAM: `docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build`
-3. **Run setup wizard or bootstrap**:
-   - Wizard: `python scripts/setup_wizard.py`
-   - Bootstrap: `bash scripts/bootstrap.sh`
-4. **Create model alias** (recommended path):
+4. **Create the Ollama alias:**
    - `bash scripts/create_ollama_model.sh`
-5. **Run doctor**:
+5. **Run doctor:**
    - `python scripts/doctor.py`
-6. **Open the app**:
+6. **Open the app:**
    - `http://localhost:8501`
+
+Notes:
+
+- `bash scripts/create_ollama_model.sh --dry-run` can run before Docker to preview resolved values.
+- Real alias creation requires the Ollama container to be running.
+- In Codex/cloud sandboxes, Docker Compose validation may be unavailable.
+- Use `python scripts/validate_compose_static.py` as Docker-free fallback validation.
+- Run real `docker compose config` validation locally or in CI.
 
 ## System requirements
 
@@ -89,6 +106,11 @@ GPU support is preserved through the explicit `docker-compose.gpu.yml` override 
 - Raw API exposure is a manual opt-in via `docker-compose.api.yml`.
 - Keep `OLLAMA_API_BIND=127.0.0.1` as the safer default when using that override, and widen only intentionally.
 - **Security warning:** exposing raw Ollama does not add app-layer authentication automatically.
+
+## App bind address warning
+
+- `APP_BIND_ADDRESS=0.0.0.0` can make the Streamlit UI reachable from other machines on your network.
+- Use `APP_BIND_ADDRESS=127.0.0.1` for local-only browser access on the same host.
 
 ## Development and testing
 

--- a/System Deployment Guide.md
+++ b/System Deployment Guide.md
@@ -93,15 +93,19 @@ Select and copy a profile `.env` template (see `examples/profiles/` and [`docs/m
 
 ## 5) Setup workflow (recommended order)
 
-1. Run setup wizard or bootstrap:
+1. Prepare `.env` (choose one):
 
 ```bash
-python scripts/setup_wizard.py
+cp .env.example .env
 # or
-bash scripts/bootstrap.sh
+cp examples/profiles/midrange-gpu.env .env
+# or
+python scripts/setup_wizard.py
 ```
 
-2. Start stack for your hardware:
+2. Review `.env` for model tag/alias, bind addresses, and context settings.
+
+3. Start stack for your hardware:
 
 ```bash
 # CPU / low-end
@@ -111,34 +115,33 @@ docker compose up -d --build
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
 ```
 
-3. Create/update Ollama alias (primary path):
+4. Create/update Ollama alias (primary path):
 
 ```bash
 bash scripts/create_ollama_model.sh
 ```
 
-4. Run doctor:
+5. Run doctor:
 
 ```bash
 python scripts/doctor.py
 ```
 
-5. Open app:
+6. Open app:
 
 ```text
 http://localhost:8501
 ```
 
-## 6) Advanced fallback: manual Modelfile editing
+Notes:
 
-Use this only if the helper script cannot satisfy your custom runtime needs.
+- `bash scripts/create_ollama_model.sh --dry-run` can run before Docker to preview generated settings.
+- Real alias creation (`bash scripts/create_ollama_model.sh`) requires the Ollama container to be running.
+- In Codex/cloud sandboxes, Docker Compose validation may be unavailable; use `python scripts/validate_compose_static.py` and run `docker compose config` locally or in CI.
 
-- Enter Ollama container.
-- Create a deployment profile file (for example under `examples/profiles/`) and keep model settings there rather than direct source edits.
-- Run `ollama create <alias> -f <modelfile>`.
-- Keep `LLM_MODEL_NAME` aligned with your alias in `.env`.
+## 6) Optional advanced alias customization
 
-Profile-driven configuration is preferred over manual per-deployment source changes.
+If you need custom runtime parameters beyond profile defaults, prefer editing `.env`/profile values first and then re-running `bash scripts/create_ollama_model.sh`.
 
 ## 7) Optional shared Ollama API exposure
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -19,7 +19,21 @@ Notes:
 - Codex web/cloud execution environments may not include the Docker CLI.
 - For Compose-related changes, run Docker Compose validation locally or in GitHub Actions before merging.
 - `python scripts/validate_compose_static.py` is the Docker-free fallback validator.
+- `docker compose config` remains the real runtime Compose validation and should run locally or in CI.
 - When PowerShell is unavailable in CI/Codex, validate `scripts/bootstrap.ps1` with static contract tests (no `pwsh` runtime required).
+
+## Relationship to manual setup
+
+If you skip bootstrap, follow the ordered manual path from `README.md`:
+
+1. Prepare `.env` (copy `.env.example`, copy a profile from `examples/profiles/`, or run `python scripts/setup_wizard.py`).
+2. Review `.env`.
+3. Run `docker compose up -d --build` (or GPU override variant).
+4. Run `bash scripts/create_ollama_model.sh`.
+5. Run `python scripts/doctor.py`.
+6. Open Streamlit.
+
+`bash scripts/create_ollama_model.sh --dry-run` is safe before Docker; non-dry-run alias creation requires a running Ollama container.
 
 ## Linux / macOS / WSL
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,12 @@ These four options work together but are not interchangeable:
 
 Exposing raw Ollama on the network is optional and should be deliberate: direct clients bypass EphemerAI UI/session privacy boundaries.
 
+Default Compose keeps raw Ollama internal-only. External/raw access is opt-in via `docker-compose.api.yml`, with `OLLAMA_API_BIND=127.0.0.1` as the safer default bind.
+
+## App bind warning
+
+`APP_BIND_ADDRESS=0.0.0.0` allows the Streamlit app to listen on all interfaces and can make it reachable from other machines on the same network. Use `APP_BIND_ADDRESS=127.0.0.1` for host-local access only.
+
 ## `OLLAMA_NO_CLOUD` guidance
 
 `OLLAMA_NO_CLOUD` defaults to `1` and disables Ollama cloud features so deployment behavior remains local-only/privacy-aligned. Do not change this unless you intentionally want Ollama cloud features and understand the privacy implications.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -37,6 +37,11 @@ Run doctor:
 - After upgrading Docker, Ollama, or GPU/container runtime components.
 - During troubleshooting when users report app/backend connectivity issues.
 
+For first-time manual setup order, run doctor after:
+1) preparing/reviewing `.env`, 2) `docker compose up -d --build`, and 3) `bash scripts/create_ollama_model.sh`.
+
+In Docker-limited Codex/cloud sandboxes, use `python scripts/validate_compose_static.py` as a fallback check; run `docker compose config` locally or in CI for real Compose validation.
+
 ## Status meanings: PASS, WARN, FAIL
 
 - **PASS**: Check looks healthy for expected default deployment behavior.
@@ -116,4 +121,3 @@ EphemerAl Doctor — Installation & Runtime Health
   What we found: OLLAMA_NO_CLOUD is explicitly disabled.
   How to fix: Set OLLAMA_NO_CLOUD=1 unless you explicitly want cloud features.
 ```
-

--- a/docs/model-profiles.md
+++ b/docs/model-profiles.md
@@ -38,8 +38,11 @@ From repository root:
 ```bash
 cp examples/profiles/midrange-gpu.env .env
 bash scripts/create_ollama_model.sh --dry-run
+docker compose up -d --build
 bash scripts/create_ollama_model.sh
 ```
+
+`--dry-run` works before Docker and previews resolved settings only. Real alias creation requires the Ollama container to be running.
 
 Swap `midrange-gpu.env` for another profile if needed.
 

--- a/docs/setup-wizard.md
+++ b/docs/setup-wizard.md
@@ -43,6 +43,8 @@ python scripts/setup_wizard.py --help
 
 - The wizard does not make live network calls by itself.
 - Service-start/model-download actions happen only if you approve the optional commands.
+- `bash scripts/create_ollama_model.sh --dry-run` can be used before Docker to preview values; real model alias creation needs a running Ollama container.
 - The midrange profile default uses `qwen3:8b`, which is text-only (not a vision model).
 - Raw Ollama API exposure is a manual, opt-in deployment override using `docker-compose.api.yml`.
   Keep `OLLAMA_API_BIND=127.0.0.1` as the safer default unless you intentionally need broader access.
+- In Codex/cloud sandboxes, Docker Compose validation may be unavailable; use `python scripts/validate_compose_static.py` there and run `docker compose config` locally or in CI.

--- a/tests/test_bootstrap_script.py
+++ b/tests/test_bootstrap_script.py
@@ -4,6 +4,9 @@ import subprocess
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
@@ -19,7 +22,7 @@ def _make_fixture_repo(tmp_path: Path) -> Path:
     scripts_dir = repo / "scripts"
     scripts_dir.mkdir(parents=True)
 
-    source_bootstrap = Path("/workspace/EphemerAl/scripts/bootstrap.sh").read_text(encoding="utf-8")
+    source_bootstrap = (REPO_ROOT / "scripts" / "bootstrap.sh").read_text(encoding="utf-8")
     _write(scripts_dir / "bootstrap.sh", source_bootstrap)
     _make_exec(scripts_dir / "bootstrap.sh")
 
@@ -80,3 +83,8 @@ def test_bootstrap_yes_creates_env_without_wizard(tmp_path: Path) -> None:
     assert "OLLAMA_NO_CLOUD=1" in created_env
     assert "Created .env from .env.example" in result.stdout
     assert "setup_wizard.py" not in result.stdout
+
+
+def test_bootstrap_test_has_no_codex_workspace_path_dependency() -> None:
+    text = (REPO_ROOT / "tests" / "test_bootstrap_script.py").read_text(encoding="utf-8")
+    assert ("/workspace" + "/EphemerAl") not in text

--- a/tests/test_docs_setup_contracts.py
+++ b/tests/test_docs_setup_contracts.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+def test_readme_public_default_and_text_only_contracts() -> None:
+    text = Path('README.md').read_text(encoding='utf-8')
+    assert 'qwen3:8b' in text
+    assert 'text-only' in text
+
+
+def test_readme_manual_order_has_compose_before_model_creation() -> None:
+    text = Path('README.md').read_text(encoding='utf-8')
+    compose_idx = text.find('docker compose up -d --build')
+    create_idx = text.find('bash scripts/create_ollama_model.sh')
+    assert compose_idx != -1 and create_idx != -1
+    assert compose_idx < create_idx
+
+
+def test_no_stale_readme_references() -> None:
+    text = Path('README.md').read_text(encoding='utf-8')
+    assert 'static/logo.svg' not in text
+    assert ('Ephemeral ' + 'Screenshot.jpg') not in text
+    assert 'EXPOSE_RAW_OLLAMA_API' not in text


### PR DESCRIPTION
### Motivation

- Make first-run experience simpler by promoting a one-command bootstrap flow and clarifying the explicit manual setup order. 
- Reduce user errors by documenting when `docker compose up` must run relative to creating an Ollama alias and by warning about app bind address exposure. 
- Improve CI/locally runnable tests by removing hard-coded workspace path assumptions and adding README contract checks.

### Description

- Promote `bash scripts/bootstrap.sh` as a recommended short bootstrap path and add a clear A/B quickstart split in `README.md`. 
- Reorder and clarify the manual setup steps across `README.md`, `System Deployment Guide.md`, `docs/bootstrap.md`, `docs/setup-wizard.md`, and `docs/doctor.md` so that `.env` preparation, `docker compose up`, then `bash scripts/create_ollama_model.sh` are the expected sequence, and add notes about `--dry-run` and Compose validation. 
- Add app bind-address warnings and default Compose internal-only note in `README.md`, `docs/configuration.md`, and `README` to highlight `APP_BIND_ADDRESS` and `OLLAMA_API_BIND` risks. 
- Tweak `docs/model-profiles.md` quick-start to include `docker compose up -d --build` and add related explanatory notes. 
- Update `tests/test_bootstrap_script.py` to resolve `scripts/bootstrap.sh` relative to the repository root instead of a hard-coded `/workspace` path and add a unit asserting no workspace dependency. 
- Add new `tests/test_docs_setup_contracts.py` to assert README contains the public default model (`qwen3:8b`), that `docker compose up` appears before `bash scripts/create_ollama_model.sh`, and that several stale asset references are absent.

### Testing

- Ran the test suite with `pytest -q`, which executed the updated and new tests including `tests/test_bootstrap_script.py` and `tests/test_docs_setup_contracts.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41d5195808328875985237e6056c9)