### PR TITLE
Harden public-release UI HTML rendering and chat composer fallback

### DIFF
--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -71,6 +71,11 @@ st.set_page_config(
     },
 )
 
+# Escape env/config-provided branding strings before injecting into custom HTML.
+APP_DISPLAY_NAME_HTML = html_escape(APP_DISPLAY_NAME)
+APP_SUBTITLE_HTML = html_escape(APP_SUBTITLE)
+APP_WELCOME_SUBTITLE_HTML = html_escape(APP_WELCOME_SUBTITLE)
+
 def load_css(path: str = "theme.css") -> None:
     """Load optional CSS overrides to customize Streamlit's default look."""
     css_path = pathlib.Path(path)
@@ -240,9 +245,9 @@ with st.sidebar:
         st.markdown(
             f"""
             <div class="sidebar-brand">
-                <img src="data:{logo.mime_type};base64,{logo.b64}" alt="{APP_DISPLAY_NAME} logo" class="sidebar-brand-logo">
-                <div class="sidebar-brand-title">{APP_DISPLAY_NAME}</div>
-                <div class="sidebar-brand-subtitle">{APP_SUBTITLE}</div>
+                <img src="data:{logo.mime_type};base64,{logo.b64}" alt="{APP_DISPLAY_NAME_HTML} logo" class="sidebar-brand-logo">
+                <div class="sidebar-brand-title">{APP_DISPLAY_NAME_HTML}</div>
+                <div class="sidebar-brand-subtitle">{APP_SUBTITLE_HTML}</div>
             </div>
             """,
             unsafe_allow_html=True,
@@ -252,8 +257,8 @@ with st.sidebar:
             f"""
             <div class="sidebar-brand">
                 <div class="sidebar-brand-fallback">E</div>
-                <div class="sidebar-brand-title">{APP_DISPLAY_NAME}</div>
-                <div class="sidebar-brand-subtitle">{APP_SUBTITLE}</div>
+                <div class="sidebar-brand-title">{APP_DISPLAY_NAME_HTML}</div>
+                <div class="sidebar-brand-subtitle">{APP_SUBTITLE_HTML}</div>
             </div>
             """,
             unsafe_allow_html=True,
@@ -322,9 +327,10 @@ prompt_in = st.chat_input(
 )
 
 # Streamlit internal API note (1.56): st._bottom draws into the same native
-# bottom dock used by st.chat_input. Keeping the toggle in this dock avoids
-# viewport-fixed overlays that can interfere with chat streaming layout.
-with st._bottom:
+# bottom dock used by st.chat_input. Keep a public-API fallback to avoid
+# hard failure if this private API changes or is unavailable.
+composer_root = getattr(st, "_bottom", None) or st.container()
+with composer_root:
     with st.container(key="composer_toggle_row"):
         thinking_mode = st.toggle(
             "Thinking Mode",
@@ -347,8 +353,8 @@ if st.session_state.show_welcome:
     st.markdown(
         f"""
         <section class="welcome-shell" aria-label="Welcome">
-          <h1 class="welcome-heading">Welcome to <span class="welcome-heading-brand">{APP_DISPLAY_NAME}</span></h1>
-          <p class="welcome-subtitle">{APP_WELCOME_SUBTITLE}</p>
+          <h1 class="welcome-heading">Welcome to <span class="welcome-heading-brand">{APP_DISPLAY_NAME_HTML}</span></h1>
+          <p class="welcome-subtitle">{APP_WELCOME_SUBTITLE_HTML}</p>
 
           <div class="welcome-card">
             <div class="welcome-features" role="list">
@@ -356,7 +362,7 @@ if st.session_state.show_welcome:
                 <div class="feature-badge feature-badge-blue">+</div>
                 <div class="feature-copy">
                   <div class="feature-copy-strong">Attach files, not just prompts</div>
-                  <div class="feature-copy-muted">Images, PDFs, Office files, spreadsheets, text, and more.</div>
+                  <div class="feature-copy-muted">Upload images, PDFs, Office files, spreadsheets, text, and more. Image analysis requires a vision-capable model; the default qwen3:8b profile is text-only.</div>
                 </div>
               </div>
               <div class="welcome-feature" role="listitem">

--- a/tests/test_logo_mime_contracts.py
+++ b/tests/test_logo_mime_contracts.py
@@ -15,6 +15,6 @@ def test_logo_mime_type_map_supports_expected_extensions():
 
 def test_logo_rendering_uses_display_name_alt_text_and_fallback_branding():
     app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
-    assert 'alt="{APP_DISPLAY_NAME} logo"' in app_text
-    assert '<div class="sidebar-brand-title">{APP_DISPLAY_NAME}</div>' in app_text
-    assert '<div class="sidebar-brand-subtitle">{APP_SUBTITLE}</div>' in app_text
+    assert 'alt="{APP_DISPLAY_NAME_HTML} logo"' in app_text
+    assert '<div class="sidebar-brand-title">{APP_DISPLAY_NAME_HTML}</div>' in app_text
+    assert '<div class="sidebar-brand-subtitle">{APP_SUBTITLE_HTML}</div>' in app_text

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -69,7 +69,7 @@ def test_welcome_state_copy_contracts():
     assert "Attach files, not just prompts" in app_text
     assert "Local and session-only" in app_text
     assert "Verify important answers" in app_text
-    assert "Images, PDFs, Office files, spreadsheets, text, and more." in app_text
+    assert "Image analysis requires a vision-capable model; the default qwen3:8b profile is text-only." in app_text
     assert "No account or saved chat history in this app. New Chat clears messages and uploads." in app_text
     assert (
         "This local model has no live web access and may be wrong, especially on current facts." in app_text
@@ -81,6 +81,19 @@ def test_new_chat_labels_and_placeholder_contracts():
     assert "Ask a question or attach files..." in app_text
     assert "New Chat" in app_text
     assert "🔄 New Chat" in app_text
+
+
+def test_branding_strings_are_escaped_before_unsafe_html_rendering():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert "APP_DISPLAY_NAME_HTML = html_escape(APP_DISPLAY_NAME)" in app_text
+    assert "APP_SUBTITLE_HTML = html_escape(APP_SUBTITLE)" in app_text
+    assert "APP_WELCOME_SUBTITLE_HTML = html_escape(APP_WELCOME_SUBTITLE)" in app_text
+    assert 'unsafe_allow_html=True' in app_text
+
+
+def test_private_bottom_api_has_public_fallback():
+    app_text = (REPO_ROOT / "ephemeral_app.py").read_text(encoding="utf-8")
+    assert 'composer_root = getattr(st, "_bottom", None) or st.container()' in app_text
 
 
 def test_docker_service_name_defaults_are_preserved():
@@ -142,4 +155,3 @@ def test_dockerfile_upload_size_uses_runtime_env_and_no_hardcoded_50():
     assert 'maxUploadSize = 50' not in dockerfile_text
     assert '--server.maxUploadSize="${MAX_UPLOAD_MB:-50}"' in dockerfile_text
     assert 'CMD ["streamlit", "run"' not in dockerfile_text
-


### PR DESCRIPTION
### Motivation
- Prevent unescaped env/config-provided branding strings from being injected into `unsafe_allow_html=True` HTML blocks to avoid inadvertent HTML/JS injection risks. 
- Avoid depending unconditionally on Streamlit private API `st._bottom` to prevent hard failures if the private API changes. 
- Ensure the public-facing welcome/sidebar copy does not imply the default text-only model can analyze images, while preserving the ability to upload images and documents. 
- Preserve existing privacy and model-default behavior (no persistence or logging, default `qwen3:8b` text-only profile remains unchanged). 

### Description
- Introduced escaped branding variables `APP_DISPLAY_NAME_HTML`, `APP_SUBTITLE_HTML`, and `APP_WELCOME_SUBTITLE_HTML` (via `html_escape`) and used them in sidebar and welcome HTML and image `alt` text. 
- Replaced unconditional `with st._bottom:` usage with a safe fallback `composer_root = getattr(st, "_bottom", None) or st.container()` and `with composer_root:` so the composer toggle still renders even if `_bottom` is unavailable. 
- Updated welcome feature copy to clearly state that image analysis requires a vision-capable model and that the public default `qwen3:8b` profile is text-only while preserving the rest of the layout and messaging. 
- Updated static contract tests (`tests/test_ui_static_contracts.py`, `tests/test_logo_mime_contracts.py`) to assert presence of escaped branding variables, `_bottom` fallback, and the revised welcome copy. 
- No changes were made to model defaults, high-VRAM profile behavior, Ollama/Tika endpoints, or any persistence/logging semantics. 

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` and it completed successfully. 
- Ran `python -m pytest -q` and the full test suite passed (`113 passed`). 
- Ran `python scripts/audit_public_release.py` and it reported no findings. 
- Ran `python scripts/validate_compose_static.py` and all compose validations passed. 
- Ran `bash -n scripts/*.sh` and shell syntax checks passed. 
- Ran `ruff check .` and linter checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50bad4f8c83289cfbce878b47afc8)