### PR TITLE
Retain and document upstream `TIKA_CLIENT_ONLY` in Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       - ENABLE_TOKEN_BUDGETING=${ENABLE_TOKEN_BUDGETING:-true}
       - TIKA_URL=${TIKA_URL:-http://tika-server:9998}
       - TIKA_TIMEOUT_S=${TIKA_TIMEOUT_S:-120}
+      # Upstream tika-python flag: keep client-only HTTP mode (no local Tika server management in app container).
       - TIKA_CLIENT_ONLY=true
       - STREAMLIT_SERVER_HEADLESS=true
       - STREAMLIT_SERVER_ADDRESS=0.0.0.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,8 @@ Default Compose keeps raw Ollama internal-only. External/raw access is opt-in vi
 
 `MAX_UPLOAD_MB` is the single user-facing upload limit: it is enforced by the app upload guardrails and passed to the Dockerized Streamlit server runtime upload cap. Very large files can still fail due to browser limits, Apache Tika parsing/memory constraints, or model context/token budgeting limits.
 
+Document parsing in the app is always performed through the external Apache Tika service URL (`TIKA_URL`, default `http://tika-server:9998` in Compose). `TIKA_CLIENT_ONLY` is an upstream/internal `tika-python` environment variable retained for predictable client-only behavior and is not an app-specific feature toggle.
+
 | Option | Default | Required? | Valid values/range | What it does | When to change it |
 |---|---|---|---|---|---|
 | `APP_DISPLAY_NAME` | `EphemerAI` | No | Non-empty string | Main app brand name in UI. | Change for your organization/product branding. |
@@ -70,6 +72,7 @@ Default Compose keeps raw Ollama internal-only. External/raw access is opt-in vi
 | `ENABLE_TOKEN_BUDGETING` | `true` | No | `true`/`false` | Enables app-side context budgeting safeguards. | Disable only for controlled experiments. |
 | `TIKA_URL` | `http://tika-server:9998` | Yes (unless app default matches environment) | URL to Apache Tika server | Document parsing backend endpoint. | Point to external Tika or different network path. |
 | `TIKA_TIMEOUT_S` | `120` | No | Positive integer seconds | Timeout for document parsing requests. | Increase for large/complex documents. |
+| `TIKA_CLIENT_ONLY` | `true` (Compose default) | No | `true`/`false` (forwarded to upstream `tika-python`) | Internal `tika-python` client mode flag; in this stack it keeps parsing in REST-client mode against `TIKA_URL` rather than trying to manage a local Tika JVM in the app container. | Most users should leave this as-is; change only if you are intentionally changing upstream `tika-python` behavior. |
 | `OLLAMA_API_BIND` | `127.0.0.1` | No | Bind address/IP | Bind used when intentionally exposing raw Ollama via compose override. | Change only when deliberately sharing raw API. |
 | `OLLAMA_ORIGINS` | _(empty)_ | No | Comma-separated origins or empty | Allowed origins for Ollama API/CORS behavior. | Required for browser-based external clients. |
 | `OLLAMA_NO_CLOUD` | `1` | No | `0` or `1` | Disables Ollama cloud features when `1`. | Change only if intentionally enabling cloud features. |

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -155,3 +155,20 @@ def test_dockerfile_upload_size_uses_runtime_env_and_no_hardcoded_50():
     assert 'maxUploadSize = 50' not in dockerfile_text
     assert '--server.maxUploadSize="${MAX_UPLOAD_MB:-50}"' in dockerfile_text
     assert 'CMD ["streamlit", "run"' not in dockerfile_text
+
+
+def test_tika_configuration_docs_and_compose_contracts():
+    compose_text = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    docs_text = (REPO_ROOT / "docs/configuration.md").read_text(encoding="utf-8")
+    tika_client_text = (REPO_ROOT / "ephemeral/tika_client.py").read_text(encoding="utf-8")
+
+    assert "TIKA_URL=${TIKA_URL:-http://tika-server:9998}" in compose_text
+    assert "TIKA_CLIENT_ONLY=true" in compose_text
+    assert "upstream tika-python" in compose_text.lower()
+
+    assert "`TIKA_URL`" in docs_text
+    assert "`TIKA_CLIENT_ONLY`" in docs_text
+    assert "Most users should leave this as-is" in docs_text
+
+    assert "from tika import parser" in tika_client_text
+    assert "serverEndpoint=TIKA_URL" in tika_client_text


### PR DESCRIPTION
### Motivation
- Verify whether the `TIKA_CLIENT_ONLY` environment variable is an active upstream `tika-python` flag and avoid removing what may be a valid dependency-level setting. 
- Ensure document parsing remains performed via the external Tika service (`TIKA_URL`) and do not weaken privacy or server-management behavior by introducing local Tika control in the app container.

### Description
- Inspected the installed `tika` dependency and confirmed `tika==3.1.0` contains references to `TIKA_CLIENT_ONLY` in `tika.tika`, so the flag is preserved rather than removed. 
- Added an inline comment in `docker-compose.yml` next to `TIKA_CLIENT_ONLY=true` explaining it is an upstream `tika-python` client-mode flag and not an app-specific toggle. 
- Updated `docs/configuration.md` to document that parsing is performed via `TIKA_URL` (default `http://tika-server:9998`) and added a `TIKA_CLIENT_ONLY` row explaining the upstream/internal purpose and recommended default. 
- Added a static contract test in `tests/test_ui_static_contracts.py` to assert Compose still wires `TIKA_URL` to `tika-server`, keeps `TIKA_CLIENT_ONLY=true` and upstream context, docs contain `TIKA_URL`/`TIKA_CLIENT_ONLY`, and the app uses `parser.from_buffer(..., serverEndpoint=TIKA_URL)`.

### Testing
- Ran the `tika` inspection snippet (the provided Python snippet) and confirmed the installed `tika` distribution is `3.1.0` and that `TIKA_CLIENT_ONLY`/`TikaClientOnly` references exist in `tika.tika`. 
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` and it completed successfully. 
- Ran `python -m pytest -q` and all tests passed (`114 passed`). 
- Ran repository static checks `python scripts/audit_public_release.py`, `python scripts/validate_compose_static.py`, `bash -n scripts/*.sh`, and `ruff check .`, and they all returned clean/pass results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50cf5763c832893214fe7f9880217)