### PR TITLE
Fix dotenv export handling in create_ollama_model.sh

### DIFF
--- a/scripts/create_ollama_model.sh
+++ b/scripts/create_ollama_model.sh
@@ -61,8 +61,7 @@ load_selected_dotenv() {
     fi
     local parsed
     parsed="$(read_dotenv_value "${raw_value}")"
-    printf -v "${key}" '%s' "${parsed}"
-    export "${key}"
+    export "${key}=${parsed}"
   done < "${dotenv_path}"
 }
 


### PR DESCRIPTION
### Motivation
- ShellCheck flagged `scripts/create_ollama_model.sh` (SC2163) for its dotenv export pattern during the final public-release regression run, which caused a lint/regression failure despite correct runtime behavior.  

### Description
- Replace the two-step `printf -v "${key}" ...` + `export "${key}"` pattern with a single `export "${key}=${parsed}"` to correctly export parsed dotenv key/value pairs without sourcing; modified file: `scripts/create_ollama_model.sh`.  

### Testing
- Ran `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py`, `python -m pytest -q` (114 tests passed), `python scripts/audit_public_release.py` (No findings), `python scripts/validate_compose_static.py` (passes), `python scripts/doctor.py` (ran; reported expected warnings about missing `.env` and Docker unavailable), `bash scripts/create_ollama_model.sh --dry-run` across no `.env`, `.env.example`, and all `examples/profiles/*.env` (dry-run succeeded), `bash scripts/bootstrap.sh --dry-run` and `--dry-run --yes` (side-effect-free), `bash -n scripts/*.sh`, `shellcheck scripts/*.sh`, `ruff check .`, and the requested ripgrep inspections; Docker and PowerShell checks were explicitly skipped in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50e182f3083289970b00befbf943b)