### PR TITLE
Release-readiness: depersonalize license, docs/dockerignore, wizard/doctor/welcome copy fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,6 +48,7 @@ Thumbs.db
 # Non-runtime docs and local media artifacts
 AGENTS.md
 README.md
+docs/
 LICENSE.md
 System Deployment Guide.md
 docker-compose.yml

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@
 # - Underlying Ollama source model pulled/used by profile tooling
 LLM_MODEL_NAME=ephemeral-default
 OLLAMA_MODEL_SOURCE=qwen3:8b
+# Optional: container name used by scripts/create_ollama_model.sh.
+# Must match docker-compose.yml if you customize the Ollama container name.
+# OLLAMA_CONTAINER=ollama
 
 # Public default context window for app-side token budgeting.
 LLM_CONTEXT_TOKENS=32768
@@ -52,6 +55,7 @@ LLM_TOP_P=0.8
 LLM_PRESENCE_PENALTY=1.5
 LLM_REASONING_EFFORT=none
 LLM_THINKING_EFFORT=
+# Blank resolves to app default `high` when Thinking Mode is enabled.
 LLM_SHOW_REASONING=false
 LLM_MAX_TOKENS=
 LLM_SUPPORTS_VISION=
@@ -64,7 +68,7 @@ OLLAMA_NUM_PREDICT=-1
 OLLAMA_TEMPERATURE=0.7
 OLLAMA_TOP_P=0.8
 OLLAMA_TOP_K=40
-OLLAMA_MIN_P=0.0
+OLLAMA_MIN_P=0
 OLLAMA_REPEAT_PENALTY=1.1
 OLLAMA_KV_CACHE_TYPE=f16
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-**Copyright (c) 2025 Ethan Owens**
+**Copyright (c) 2025 The EphemerAl Contributors**
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Bootstrap handles `.env` setup, starts the Compose stack, creates the local Olla
 ### B) Manual path (explicit order)
 
 1. **Prepare `.env` (choose one):**
-   - `cp .env.example .env`, or
+   - `cp .env.example .env` for the full editable configuration surface, or
    - `cp examples/profiles/midrange-gpu.env .env` (or another profile from `examples/profiles/`), or
-   - `python scripts/setup_wizard.py`
-2. **Review `.env` values** (model tag/alias, ports, bind addresses, context).
+   - `python scripts/setup_wizard.py` for a smaller safe `.env` containing key choices.
+2. **Review `.env` values** (model tag/alias, ports, bind addresses, context). Missing keys continue to use documented Compose/app defaults.
 3. **Start services:**
    - CPU/low-end (default): `docker compose up -d --build`
    - GPU/high-VRAM: `docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,8 @@
 
 EphemerAI deployments are configured primarily through environment variables in a `.env` file. Start by copying `.env.example` to `.env`, then edit values for your environment.
 
+If you use `python scripts/setup_wizard.py`, it writes a smaller safe `.env` with key choices rather than the full surface. Missing keys still fall back to documented Compose/app defaults. Use `.env.example` directly when you want the most complete editable surface.
+
 - **Main configuration surface:** `.env`
 - **Why:** keeps branding, model choices, networking, and runtime tuning deployment-specific without hard-coding source changes.
 - **Default behavior:** `.env.example` is privacy-aligned for local/container deployment and should work for most users with minimal edits.
@@ -84,12 +86,13 @@ Document parsing in the app is always performed through the external Apache Tika
 | `OLLAMA_KV_CACHE_TYPE` | `f16` | No | Ollama-supported cache types (for example `f16`, `q8_0`; support varies by build/hardware) | KV cache precision/compression setting. | Tune memory usage vs quality/perf. |
 | `OLLAMA_FORCE_CUBLAS_LT` | `1` | No | `0` or `1` | Forces cuBLASLt path on supported NVIDIA setups. | Disable only if encountering backend issues. |
 | `OLLAMA_MODEL_SOURCE` | `qwen3:8b` | Yes for profile/bootstrap workflows | Valid Ollama model tag | Upstream model tag pulled/used to build local alias. | Retarget deployment model family/size. |
+| `OLLAMA_CONTAINER` | `ollama` (script default) | No (script-only) | Existing Docker container name | Internal helper for `scripts/create_ollama_model.sh` to target the Ollama container. | Set only if you customize Ollama container naming in compose. |
 | `OLLAMA_NUM_CTX` | `32768` | No | Positive integer tokens (bounded by model/runtime/hardware limits) | Runtime context window for Ollama model profile/alias. | Increase/decrease based on VRAM and use case. |
 | `OLLAMA_NUM_PREDICT` | `-1` | No | Integer (`-1` for unlimited/default behavior, otherwise positive cap) | Default generation length behavior at Ollama runtime layer. | Cap outputs globally at runtime layer. |
 | `OLLAMA_TEMPERATURE` | `0.7` | No | Float usually `0.0–2.0` | Ollama-side default temperature for alias/runtime profile. | Align runtime defaults with desired style. |
 | `OLLAMA_TOP_P` | `0.8` | No | Float `0.0–1.0` | Ollama-side nucleus sampling default. | Tune diversity at runtime profile layer. |
 | `OLLAMA_TOP_K` | `40` | No | Positive integer | Ollama-side top-k sampling default. | Adjust token selection sharpness. |
-| `OLLAMA_MIN_P` | `0.0` | No | Float `0.0–1.0` | Ollama-side minimum-probability sampling threshold. | Prune unlikely tokens for stability/speed. |
+| `OLLAMA_MIN_P` | `0` | No | Float `0.0–1.0` | Ollama-side minimum-probability sampling threshold. | Prune unlikely tokens for stability/speed. |
 | `OLLAMA_REPEAT_PENALTY` | `1.1` | No | Positive float (commonly around `0.8–2.0`) | Ollama-side repetition penalty. | Reduce loops/repetition artifacts. |
 | `TIKA_JAVA_TOOL_OPTIONS` | `-Xmx2g -Xms512m` | No | Java options string | JVM memory/runtime flags for Tika container. | Increase heap or tune GC for heavy docs. |
 | `APP_BIND_ADDRESS` | `0.0.0.0` | No | Valid bind host/IP | Streamlit server bind address. | Lock to localhost or expose on LAN. |

--- a/docs/setup-wizard.md
+++ b/docs/setup-wizard.md
@@ -1,6 +1,13 @@
 # Setup Wizard (`scripts/setup_wizard.py`)
 
 The setup wizard provides a lightweight, line-oriented terminal flow for first-time setup.
+
+## Output scope vs `.env.example`
+
+- `cp .env.example .env` gives the **full editable configuration surface**.
+- `python scripts/setup_wizard.py` writes a **smaller safe `.env`** with key deployment choices.
+- Any keys not written by the wizard still fall back to documented Compose/app defaults.
+- If you want the most complete editable surface, start from `.env.example` and edit directly.
 It is intended for users who can run commands and prefer profile-driven configuration rather than direct source changes.
 
 ## What it does

--- a/ephemeral_app.py
+++ b/ephemeral_app.py
@@ -362,7 +362,7 @@ if st.session_state.show_welcome:
                 <div class="feature-badge feature-badge-blue">+</div>
                 <div class="feature-copy">
                   <div class="feature-copy-strong">Attach files, not just prompts</div>
-                  <div class="feature-copy-muted">Upload images, PDFs, Office files, spreadsheets, text, and more. Image analysis requires a vision-capable model; the default qwen3:8b profile is text-only.</div>
+                  <div class="feature-copy-muted">Upload images, PDFs, Office files, spreadsheets, text, and more. Public default text profiles are text-only; image analysis requires a vision-capable model.</div>
                 </div>
               </div>
               <div class="welcome-feature" role="listitem">

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -117,7 +117,7 @@ def _classify_ollama_ports(service: dict[str, Any]) -> tuple[bool, bool]:
         raw = str(port).strip().replace('"', "").replace("'", "")
         if "11434:11434" not in raw:
             continue
-        if raw.startswith("127.0.0.1:"):
+        if raw.startswith("127.0.0.1:") or raw.startswith("[::1]:"):
             loopback = True
         elif raw.startswith("0.0.0.0:") or raw.startswith("[::]:"):
             broad = True
@@ -248,12 +248,12 @@ def main() -> int:
         checks.append(CheckResult(WARN, "NVIDIA GPU", "Skipped because ollama container is not running.", "Start ollama and run again, or ignore on CPU-only setups."))
 
     broad_exposure, loopback_exposure = _classify_ollama_ports(ollama_service)
-    exposure_status = WARN if (broad_exposure or loopback_exposure) else PASS
+    exposure_status = WARN if broad_exposure else PASS
     exposure_detail = "No raw Ollama API port publishing detected."
     if broad_exposure:
         exposure_detail = "Potential broad exposure of raw Ollama API port 11434 detected."
     elif loopback_exposure:
-        exposure_detail = "Raw Ollama API is published on loopback (127.0.0.1) as an intentional local opt-in."
+        exposure_detail = "Raw Ollama API is published on loopback (127.0.0.1/[::1]) as an intentional local opt-in."
     checks.append(CheckResult(exposure_status, "Raw Ollama API exposure", exposure_detail, "Avoid broad 11434 publishing; keep raw Ollama internal, or use authenticated/restricted exposure for local debugging only."))
 
     no_cloud = parse_bool(env.get("OLLAMA_NO_CLOUD"))

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -26,7 +26,9 @@ def detect_platform() -> Dict[str, str | bool]:
     shell = os.environ.get("SHELL", "")
     term_program = os.environ.get("TERM_PROGRAM", "")
     in_wsl = "microsoft" in release or "wsl" in release or bool(os.environ.get("WSL_DISTRO_NAME"))
-    in_powershell = "pwsh" in os.environ.get("0", "").lower() or "powershell" in shell.lower()
+    ps_module_path = os.environ.get("PSModulePath", "")
+    shell_l = shell.lower()
+    in_powershell = bool(ps_module_path) or "pwsh" in shell_l or "powershell" in shell_l
 
     return {
         "system": system,
@@ -76,11 +78,8 @@ def parse_env_template(path: Path) -> Dict[str, str]:
 
 
 def choose_default_profile(has_nvidia: bool, platform_info: Dict[str, str | bool]) -> str:
-    if not has_nvidia:
-        return "low-end-laptop"
-    if platform_info.get("in_wsl") and has_nvidia:
-        return "midrange-gpu"
-    return "midrange-gpu"
+    _ = platform_info
+    return "midrange-gpu" if has_nvidia else "low-end-laptop"
 
 
 def prompt_text(label: str, default: str, required: bool = False) -> str:
@@ -121,7 +120,7 @@ def validate_port(value: str, field: str = "App port") -> str:
 
 
 def backup_existing_env(env_path: Path) -> Path:
-    stamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S")
     backup_path = env_path.with_suffix(env_path.suffix + f".{stamp}.bak")
     shutil.copy2(env_path, backup_path)
     return backup_path

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -92,3 +92,15 @@ def test_main_uses_ephemeral_app_remediation_and_handles_no_docker(monkeypatch, 
     assert "docker compose up -d app" not in captured
     assert "Docker-dependent checks will be skipped" in captured
     assert "NVIDIA GPU" in captured
+
+
+def test_port_exposure_loopback_ipv6_opt_in() -> None:
+    broad, loopback = _classify_ollama_ports({"ports": ["[::1]:11434:11434"]})
+    assert broad is False
+    assert loopback is True
+
+
+def test_port_exposure_broad_ipv6_bindings() -> None:
+    broad, loopback = _classify_ollama_ports({"ports": ["[::]:11434:11434"]})
+    assert broad is True
+    assert loopback is False

--- a/tests/test_ui_static_contracts.py
+++ b/tests/test_ui_static_contracts.py
@@ -69,7 +69,7 @@ def test_welcome_state_copy_contracts():
     assert "Attach files, not just prompts" in app_text
     assert "Local and session-only" in app_text
     assert "Verify important answers" in app_text
-    assert "Image analysis requires a vision-capable model; the default qwen3:8b profile is text-only." in app_text
+    assert "Public default text profiles are text-only; image analysis requires a vision-capable model." in app_text
     assert "No account or saved chat history in this app. New Chat clears messages and uploads." in app_text
     assert (
         "This local model has no live web access and may be wrong, especially on current facts." in app_text


### PR DESCRIPTION
### Motivation
- Remove personal attribution from the license and make small release-readiness cleanups required by the audit.  
- Avoid shipping docs into the runtime Docker image by ignoring `docs/` in the build context.  
- Fix fragile/incorrect heuristics and minor datetime/timestamp issues in the interactive `setup_wizard` to improve platform detection and backup behavior.  
- Reduce alarm noise from the doctor check for intended loopback-only Ollama exposures and clarify related docs/config and UI wording (without changing privacy defaults or public model defaults).

### Description
- Replaced personal copyright line in `LICENSE.md` with a contributor-based attribution.  
- Added `docs/` to `.dockerignore` so docs and future doc images are not copied into the runtime image.  
- Fixed `scripts/setup_wizard.py`: use `PSModulePath`/`SHELL` for PowerShell detection, use timezone-aware UTC for backups (`dt.datetime.now(dt.timezone.utc)`), and simplified `choose_default_profile` to return `midrange-gpu` when GPU is detected and `low-end-laptop` otherwise.  
- Improved `scripts/doctor.py` Ollama-port classification to treat `127.0.0.1:11434:11434` and `[::1]:11434:11434` as loopback opt-ins (treated as pass-with-note) while keeping broad binds (`11434:11434`, `0.0.0.0:11434:11434`, `[::]:11434:11434`) as WARN; updated messages accordingly.  
- Updated `.env.example` and `docs/configuration.md` with an `OLLAMA_CONTAINER` commented script-only setting, added a one-line `LLM_THINKING_EFFORT` comment clarifying blank→app-default `high`, and normalized `OLLAMA_MIN_P` from `0.0` to `0`.  
- Clarified README and `docs/setup-wizard.md` to explain that `cp .env.example .env` gives the full editable surface while `python scripts/setup_wizard.py` writes a smaller safe `.env` and that missing keys fall back to Compose/app defaults.  
- Removed the hard-coded `qwen3:8b` literal from the runtime welcome-card and replaced it with generic wording about public text-only profiles vs vision-capable models (tests/contracts updated to match).  
- Added IPv6 loopback/broad exposure tests and adjusted static UI contract test text to reflect the welcome-card wording change.

### Testing
- Ran automated compile and lint checks: `python -m py_compile ephemeral_app.py ephemeral/*.py scripts/*.py` succeeded and `ruff check .` passed.  
- Ran the full test suite with `python -m pytest -q` (final result: **116 passed**).  
- Ran release and compose validations: `python scripts/audit_public_release.py` (no findings), `python scripts/validate_compose_static.py` (all PASS checks), and `python scripts/doctor.py` (ran; produced expected WARNs where Docker/.env are absent in this environment but completed successfully).  
- Shell/script checks: `bash scripts/create_ollama_model.sh --dry-run` produced the resolved settings (shows `OLLAMA_CONTAINER=ollama` and `OLLAMA_MIN_P=0`), `bash -n scripts/*.sh` reported no syntax errors, and `shellcheck scripts/*.sh` returned clean; `rg` checks for the tracked strings were performed.  

Notes / workspace observations: `docs/screenshot-default-branding.jpg` is missing in this workspace (reported as expected), no binary/image files were modified, and the files changed are: `.dockerignore`, `.env.example`, `LICENSE.md`, `README.md`, `docs/configuration.md`, `docs/setup-wizard.md`, `ephemeral_app.py`, `scripts/doctor.py`, `scripts/setup_wizard.py`, `tests/test_doctor.py`, and `tests/test_ui_static_contracts.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52c4823788328ba6ff637674d668e)